### PR TITLE
Ready for Radio Testing

### DIFF
--- a/dbc/brightside.dbc
+++ b/dbc/brightside.dbc
@@ -319,37 +319,6 @@ BO_ 2550588916 ECUChargerModes: 8 ECU
  SG_ ChargingModes : 40|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 2566869221 OBCStatus: 8 OBC
- SG_ OutputVoltage : 7|16@0+ (0.1,0) [0|0] "V" Vector__XXX
- SG_ OutputCurrent : 23|16@0+ (0.1,0) [0|0] "A" Vector__XXX
- SG_ HardwareProtection : 32|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ TemepratureProtection : 33|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ InputVoltageStatus : 34|2@1+ (1,0) [0|0] "" Vector__XXX
- SG_ OutputUnderVoltage : 36|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ OutputOverVoltage : 37|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ OutputOverCurrent : 38|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ OutputShortCircuit : 39|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CommunicationStatus : 40|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ WorkingStatus : 41|2@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CompletionOfInitialization : 43|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ FanEnable : 44|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CoolingPumpFanEnable : 45|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CCsignalStatus : 48|2@1+ (1,0) [0|0] "" Vector__XXX
- SG_ CPSignalStatus : 50|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ ChargingSocketTempFault : 51|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ ElectronicLockState : 52|3@1+ (1,0) [0|0] "" Vector__XXX
- SG_ S2SwitchControlStatus : 55|1@1+ (1,0) [0|0] "" Vector__XXX
- SG_ Temperaturre : 56|8@1+ (1,-40) [0|0] "C" Vector__XXX
-
-BO_ 1872 SimulationSpeed: 4 TEL
- SG_ SimulationSpeedRec : 0|32@1+ (1,0) [0|0] "" Vector__XXX
-
-BO_ 2550588916 ECUChargerModes: 8 ECU
- SG_ MaxChargingVoltage : 0|16@1+ (0.1,0) [0|0] "V" Vector__XXX
- SG_ MaxChargingCurrent : 16|16@1+ (0.1,0) [0|0] "A" Vector__XXX
- SG_ ChargerEnables : 32|8@1+ (1,0) [0|0] "" Vector__XXX
- SG_ ChargingModes : 40|8@1+ (1,0) [0|0] "" Vector__XXX
-
-BO_ 2566869221 OBCStatus: 8 OBC
  SG_ OutputVoltage : 0|16@1+ (0.1,0) [0|0] "V" Vector__XXX
  SG_ OutputCurrent : 16|16@1+ (0.1,0) [0|0] "A" Vector__XXX
  SG_ HardwareProtection : 32|1@1+ (1,0) [0|0] "" Vector__XXX

--- a/docs/MESSAGE_FORMATS.md
+++ b/docs/MESSAGE_FORMATS.md
@@ -16,7 +16,7 @@ In the `firmware_v3` repository, the `CAN` messages are a `uint8_t` buffer that 
 
 On the parser side, we randomize CAN messages by doing the following. Note that latin-1 format is used because it can convert 0 to 255 to a **single width** character, whereas as UTF-8 can convert 0 to 127 to a single width character. Characters after this are not always single width.
 
--   8-byte current timestamp (in seconds as a double) converted to a latin-1 decoded string that is 8 characters long. When parsed this is rounded to 3 decimal places (CAN messages will not be sent at rates higher than 1ms = 0.001s).
+-   8-byte current timestamp (in seconds as an int) converted to a latin-1 decoded string that is 8 characters long.
 -   5-byte id: 1 byte for the `'#'` character and 4 bytes for the random id from the DBC.
     -   **4 bytes is necessary because extended ids are 29 bits so rounded to the nearest byte is 32 bits or 4 bytes.**
 -   8-byte data randomly generated as a an integer ranging from 0 to 2^64. This is then converted to a latin-1 decoded string that is 8 characters long.

--- a/parser/create_message.py
+++ b/parser/create_message.py
@@ -30,6 +30,12 @@ def create_message(message: str):
         elif IMU_LENGTH_MIN <= len(message) <= IMU_LENGTH_MAX:
             return IMU(message)
         else:
+            raise Exception(
+                f"Message length of {len(message)} is not a valid length for any message type\n"
+                f"      Message: {message}\n"
+                f"      Hex Message: {message.encode('latin-1').hex()}"
+            )
+        
             raise Exception(f"Message length of {len(message)} is not a valid length for any message type")
     except Exception as e:
         raise Exception(

--- a/parser/data_classes/GPS_Msg.py
+++ b/parser/data_classes/GPS_Msg.py
@@ -52,7 +52,7 @@ class GPS:
             r"HDOP: (?P<HDOP>-?\d+\.\d+), "
             r"Satellites: (?P<Satellites>\d+), "
             r"Fix: (?P<Fix>\d+), "
-            r"Time: (?P<Timestamp>\d+\.\d+)"
+            r"Time: (?P<Timestamp>\d+)"
         )
         match = re.search(pattern, self.message)
         

--- a/parser/main.py
+++ b/parser/main.py
@@ -341,7 +341,7 @@ def parse_and_write_request_bucket(bucket):
                 "result": "INFLUX_WRITE_FAIL",
                 "message": str(parse_request["message"]),
                 "error": str(e),
-                "type": type
+                "type": type 
             }
 
     return {

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -26,7 +26,7 @@ def generate_exception(e: Exception, func_name: str) -> Exception:
 CAN_LENGTH_MIN      = 21
 CAN_LENGTH_MAX      = 23
 GPS_LENGTH_MIN      = 122
-GPS_LENGTH_MAX      = 133
+GPS_LENGTH_MAX      = 205
 IMU_LENGTH_MIN      = 15
 IMU_LENGTH_MAX      = 17
 

--- a/parser/randomizer.py
+++ b/parser/randomizer.py
@@ -58,10 +58,9 @@ class RandomMessage:
         for message in CAR_DBC.messages:
             can_ids.append(message.frame_id)
 
-        # Convert current time to float bytes to latin-1 string 
-        current_time = time.time()
-        current_time_bytes = struct.pack('>d', current_time)
-        current_time_str = current_time_bytes.decode('latin-1')
+        # Convert current time to a 32 bit unsigned integer to latin-1 string 
+        current_time = int(time.time()) + (2**32 if time.time() < 0 else 0)
+        current_time_str = current_time.to_bytes(8, 'big').decode('latin-1')
 
         # random identifier
         random_identifier = random.choice(can_ids)
@@ -101,7 +100,7 @@ class RandomMessage:
         hdop = random.uniform(0, 50)
         satelliteCount = random.randint(0, 12)
         fix = random.randint(0, 1)
-        lastMeasure = round(time.time(), 1)
+        lastMeasure = int(time.time()) + (2**32 if int(time.time()) < 0 else 0)
 
         nmea_msg = "Latitude: {:.6f} {}, Longitude: {:.6f} {}, Altitude: {:.2f} meters, HDOP: {:.2f}, Satellites: {}, Fix: {}, Time: {}".format(
             abs(latitude), latSide,
@@ -126,10 +125,9 @@ class RandomMessage:
                     F - data            = 4 bytes
     """
     def random_imu_str(self) -> str:
-        # Generate a random timestamp
-        current_time = time.time()
-        current_time_bytes = struct.pack('>d', current_time)
-        timestamp = current_time_bytes.decode('latin-1')
+        # Convert current time to a 32 bit unsigned integer to latin-1 string 
+        current_time = int(time.time()) + (2**32 if time.time() < 0 else 0)
+        current_time_str = current_time.to_bytes(8, 'big').decode('latin-1')
 
 
         # Generate a random identifier
@@ -142,6 +140,6 @@ class RandomMessage:
         value_bytes = struct.pack('>f', value)
 
         # Combine all parts into a single bytes object
-        imu_bytes = timestamp + "@" + identifier + value_bytes.decode('latin-1')
+        imu_bytes = current_time_str + "@" + identifier + value_bytes.decode('latin-1')
 
         return imu_bytes

--- a/templates/TEMPLATE_MESSAGE.py
+++ b/templates/TEMPLATE_MESSAGE.py
@@ -72,7 +72,7 @@ class MESSAGE_NAME:
             raise Exception(
                 f"Could not extract {ANSI_BOLD}<MESSAGE_NAME>{ANSI_ESCAPE} message with properties: \n"
                 f"      Message Length = {len(self.message)} \n"
-                f"      Message Hex Data = {self.message.encode().hex()} \n\n"
+                f"      Message Hex Data = {self.message.encode('latin-1').hex()} \n\n"
                 f"      {ANSI_RED}Error{ANSI_ESCAPE}: \n"
                 f"      {e} \n"
                 f"      {ANSI_GREEN}Function Call Details (self.message[] bytes -> hex numbers):{ANSI_ESCAPE} \n"


### PR DESCRIPTION
Here are all the changes made:

* Changed interpretation of timestamp to be a 32 bit integer instead of a float in all data classes and randomizer. This is to align with firmware_v3. Note that everywhere in firmware_v3 the timestamp's max precision is seconds so this change made sense.

* Changed pretty printing to display timestamp field as "2024-04-18 02:43:37" instead of epoch time of "1713408217"

* Fixed duplicate DBC messages. OBCStatus message was duplicated in the DBC (one version set output voltage differently than current BOM but other version matched the BOM exactly so first version was deleted). ECUChargerModes had 2 **exact** duplicates in the DBC so I deleted one version. Lastly, SimulationSpeed also had two **exact** copies so I deleted one copy. Note that I noticed this problem when I ran sunlink and I got the following messages every run:
```
Overwriting message 'ECUChargerModes' with 'ECUChargerModes' in the name to message dictionary.
Overwriting message 'ECUChargerModes' with 'ECUChargerModes' in the frame id to message dictionary because they have identical masked frame ids 0x1806e5f4.
Overwriting message 'OBCStatus' with 'OBCStatus' in the name to message dictionary.
Overwriting message 'OBCStatus' with 'OBCStatus' in the frame id to message dictionary because they have identical masked frame ids 0x18ff50e5.
Overwriting message 'SimulationSpeed' with 'SimulationSpeed' in the name to message dictionary.
Overwriting message 'SimulationSpeed' with 'SimulationSpeed' in the frame id to message dictionary because they have identical masked frame ids 0x750.
```

* Changed log upload functionality to only log files that **do not** start with `FAILED_UPLOADS`. I made any messages which could not be uploaded be put in a file that started with `FAILED_UPLOADS` before but now I am removing the ability for them to be uploaded again because they are "wrong" data (this data would have created the custom error message which user can read to understand what went wrong).

* Fixed config table to correctly indicate is radio is being used (needs to be tested)

* Small changes in docs to match changes I made in code.

* Changed GPS message max length to 205 to allow the current implementation of firmware_v3 GPS messages to be parsed (needs to be tested). This change felt valid because we do not have any messages whose data length is anywhere near 100+.

**Changes in firmware_v3 required**
* We need to use the flipped data field bytes on Ishan's tel_v2 branch when sending/logging messages to be compatible with sunlink. I believe that enforcing this flipped byte change is good because in all use cases of this data (sunlink and manual parsing or testing) the bytes are interpreted with LSB first, however, previously it was MSB first.