### PR TITLE
Timestamps as Double and printing Milliseconds 

### DIFF
--- a/parser/data_classes/CAN_Msg.py
+++ b/parser/data_classes/CAN_Msg.py
@@ -1,7 +1,7 @@
 import struct
 from parser.parameters import *
 from time import strftime, localtime
-
+from datetime import datetime
 
 """
 CAN Message data class. Data fields are:
@@ -37,23 +37,22 @@ class CAN:
 
 
     """
-    Gets the timestamp of the message interpreted as a 32 bit unsigned integer in seconds
-
+    Gets the timestamp of the message as a 64 bit float
     Parameters:
         message_timestamp - the timestamp of the message as a latin-1 string
     
     Returns:
-        int - the timestamp of the message interpreted in seconds
+        float - the timestamp of the message
     """
     def get_timestamp(self, message_timestamp) -> float:
         try:
-            timestamp = int.from_bytes(bytearray(message_timestamp.encode('latin-1')), "big")
-            timestamp += 2**32 if timestamp < 0 else 0      # if timestamp negative then need to add 2^32 to get correct value
+            timestamp = struct.unpack('>d', message_timestamp.encode('latin-1'))[0]
+            float_timestamp = float(timestamp)
 
-            return timestamp
+            return float_timestamp
         except Exception as e:
             generate_exception(e, "get_timestamp")
-        
+
 
     """
     Gets the hex id of the message
@@ -212,8 +211,7 @@ class CAN:
             data["display_data"]["Source"].append(source)
             data["display_data"]["Class"].append(message.name)
             data["display_data"]["Measurement"].append(name)
-            data["display_data"]["Timestamp"].append(strftime('%Y-%m-%d %H:%M:%S', localtime(timestamp)))
+            data["display_data"]["Timestamp"].append(datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
             data["display_data"]["Value"].append(dbc_data)
 
         return data
-

--- a/parser/data_classes/GPS_Msg.py
+++ b/parser/data_classes/GPS_Msg.py
@@ -32,7 +32,6 @@ class GPS:
         self.data = self.extract_measurements()
         self.type = "GPS"
 
-
     """
     Extracts measurements from a GPS message based on a specified format
     Keys of the display_dict in the data dict are column headings. 

--- a/parser/data_classes/IMU_Msg.py
+++ b/parser/data_classes/IMU_Msg.py
@@ -1,6 +1,7 @@
 import struct
 from parser.parameters import *
 from time import strftime, localtime
+from datetime import datetime
 
 
 """
@@ -33,23 +34,22 @@ class IMU:
 
 
     """
-    Gets the timestamp of the message interpreted as a 32 bit unsigned integer in seconds
-
+    Gets the timestamp of the message as a 64 bit float
     Parameters:
         message_timestamp - the timestamp of the message as a latin-1 string
     
     Returns:
-        int - the timestamp of the message interpreted in seconds
+        float - the timestamp of the message
     """
     def get_timestamp(self, message_timestamp) -> float:
         try:
-            timestamp = int.from_bytes(bytearray(message_timestamp.encode('latin-1')), "big")
-            timestamp += 2**32 if timestamp < 0 else 0      # if timestamp negative then need to add 2^32 to get correct value
+            timestamp = struct.unpack('>d', message_timestamp.encode('latin-1'))[0]
+            float_timestamp = float(timestamp)
 
-            return timestamp
+            return float_timestamp
         except Exception as e:
             generate_exception(e, "get_timestamp")
-        
+   
 
     """
     Gets the value of the message as a float
@@ -138,8 +138,7 @@ class IMU:
             "Type": [id[0]],
             "Dimension": [id[1]],
             "Value": [round(value, 6)],
-            "Timestamp": [strftime('%Y-%m-%d %H:%M:%S', localtime(timestamp))],
+            "Timestamp": [datetime.fromtimestamp(timestamp).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]],
         }
         
         return data
-

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -24,7 +24,7 @@ def generate_exception(e: Exception, func_name: str) -> Exception:
 
 #  <----- Lengths of messages for differentiating message types ----->
 CAN_LENGTH_MIN      = 21
-CAN_LENGTH_MAX      = 23
+CAN_LENGTH_MAX      = 25
 GPS_LENGTH_MIN      = 122
 GPS_LENGTH_MAX      = 205
 IMU_LENGTH_MIN      = 15

--- a/parser/randomizer.py
+++ b/parser/randomizer.py
@@ -59,8 +59,10 @@ class RandomMessage:
             can_ids.append(message.frame_id)
 
         # Convert current time to a 32 bit unsigned integer to latin-1 string 
-        current_time = int(time.time()) + (2**32 if time.time() < 0 else 0)
-        current_time_str = current_time.to_bytes(8, 'big').decode('latin-1')
+        # Convert current time to float bytes to latin-1 string 
+        current_time = time.time()
+        current_time_bytes = struct.pack('>d', current_time)
+        current_time_str = current_time_bytes.decode('latin-1')
 
         # random identifier
         random_identifier = random.choice(can_ids)
@@ -100,7 +102,7 @@ class RandomMessage:
         hdop = random.uniform(0, 50)
         satelliteCount = random.randint(0, 12)
         fix = random.randint(0, 1)
-        lastMeasure = int(time.time()) + (2**32 if int(time.time()) < 0 else 0)
+        lastMeasure = round(time.time(), 1)
 
         nmea_msg = "Latitude: {:.6f} {}, Longitude: {:.6f} {}, Altitude: {:.2f} meters, HDOP: {:.2f}, Satellites: {}, Fix: {}, Time: {}".format(
             abs(latitude), latSide,
@@ -125,9 +127,10 @@ class RandomMessage:
                     F - data            = 4 bytes
     """
     def random_imu_str(self) -> str:
-        # Convert current time to a 32 bit unsigned integer to latin-1 string 
-        current_time = int(time.time()) + (2**32 if time.time() < 0 else 0)
-        current_time_str = current_time.to_bytes(8, 'big').decode('latin-1')
+        # Convert current time to float bytes to latin-1 string 
+        current_time = time.time()
+        current_time_bytes = struct.pack('>d', current_time)
+        current_time_str = current_time_bytes.decode('latin-1')
 
 
         # Generate a random identifier
@@ -143,3 +146,4 @@ class RandomMessage:
         imu_bytes = current_time_str + "@" + identifier + value_bytes.decode('latin-1')
 
         return imu_bytes
+    


### PR DESCRIPTION
* Changed interpretation of the timestamp field from a 64 bit integer to a 64 bit precision double representing time in seconds since epoch time. (Appropriate firmware changes were made and a full radio test was done with IMU data). See note on IMU parse fails below
* Using the `datetime` library I printed the timestamps with millisecond precision now.
* Changed randomizer to create 64 bit precision double timestamps.

**Example of a PARSE FAIL and millisecond precision timestamp**
![image](https://github.com/UBC-Solar/sunlink/assets/117491745/e9acfbd2-a4df-4063-a093-285d402ce815)

**Note:**
* Some **PARSE_FAILS** occurred when running the system. I created a log of all the messages that were sent and noticed that sometimes the IMU message would be sent in pieces (the longer messages are the expected and 'correct' IMU messages):
```
41cc366dfd9a9fbe4041593c0000000d0a
41cc366dfd9a9fbe4047583fd30dae0d0a
850d0a
41cc366dfe270a
41cc366dfe270a
41cc366dfe270a
41cc366dfe270a
41cc366dfeb374bc4041583be800000d0a
41cc366dfeb374bc40415a3f7cb0000d0a
```
The example I chose is on the more severe end of things. I would estimate a 20% failure rate which is quite high and thus we are **losing** data.