### PR TITLE
Fixed GPS timestamping + dbgfile 

### DIFF
--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -318,15 +318,15 @@ def process_response(future: concurrent.futures.Future, args):
         print(fail_msg)
 
         # If log upload AND parse fails then log again to the FAILED_UPLOADS.txt file. If no log upload do normal
-        write_to_log_file(parse_response['message'], os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else LOG_FILE_NAME)
-        write_to_log_file(fail_msg + '\n', os.path.join(LOG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
+        write_to_log_file(parse_response['message'], os.path.join(LOG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else LOG_FILE_NAME)
+        write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
     elif parse_response["result"] == "INFLUX_WRITE_FAIL":
         print(f"Failed to write measurements for {parse_response['type']} message to InfluxDB!")
         print(parse_response)
 
         # If log upload AND INFLUX_WRITE_FAIL fails then log again to the FAILED_UPLOADS.txt file. If no log upload do normal
         write_to_log_file(parse_response['message'], os.path.join(LOG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else LOG_FILE_NAME)
-        write_to_log_file(fail_msg + '\n', os.path.join(LOG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
+        write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
     else:
         print(f"Unexpected response: {parse_response['result']}")
 
@@ -557,10 +557,6 @@ def main():
 
     global executor
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=DEFAULT_MAX_WORKERS)
-
-    if args.log_upload:
-        upload_logs(args, live_filters)
-        return 0
     
     global start_time
     start_time = datetime.now()
@@ -573,12 +569,16 @@ def main():
         os.makedirs(LOG_DIRECTORY)
     if LOG_FILE and not os.path.exists(DEBUG_DIRECTORY):
         os.makedirs(DEBUG_DIRECTORY)
-
+    
     global LOG_FILE_NAME 
     global DEBUG_FILE_NAME
     LOG_FILE_NAME = os.path.join(LOG_DIRECTORY, LOG_FILE)
     DEBUG_FILE_NAME = os.path.join(DEBUG_DIRECTORY, LOG_FILE)
     
+    if args.log_upload:
+        upload_logs(args, live_filters)
+        return 0
+
     while True:
         message: bytes
 


### PR DESCRIPTION
**Purpose**:
* Previous GPS messages were printed as 025914 or 112548. Upon closer inspection this is actually just HHMMSS. Thus, this branch fixed the timestamp from printing "025914" to "2024-05-11 02:59:14.000", for example. **Note that the date is decided using `time.time()` to get the current epoch time and then this is rounded down to a whole day. It is onto this rounded down timestamp the GPS timestamp is added**. This needed to be done because GPS only provides the hours, minutes, and seconds in GMT. See this [Monday update](https://ubcsolar.monday.com/boards/3313681052/pulses/6615342892?term=timestamp&termColumns=XQAAAAJvAAAAAAAAAABBKoJ4MRmOSvlPTDV2Qow42wcHf67VzsBdKlCbBGsDUWUe9ZBNkdE8anb-D9z8-b1wBiZRkBInPvJQFM9-LnxSVAbsA45GP2YL3_0uWUA) for more details.

**Changes**:
* A mistake in the `user/Aarjavjain101/log_dbg_fails` branch was fixed in which the `dbgfiles` directory was not created when link telemetry was ran with the -u option for the first time. To fix this, the logic to perform log uploading was put **after** creating the necessary directories. Additionally, a small error in which the pretty printed parse fail message would go to the `logfiles` folder instead of the `dbgfiles` folder was fixed by switching the directory arguments in the `write_to_log_files` function.
* In the GPS data class, the necessary functions to format the timestamp correctly were implemented and tested with synced GPS data coming over radio and observing the timestamps:
![image](https://github.com/UBC-Solar/sunlink/assets/117491745/a2bfb7a8-f052-419d-9d20-497645911dee)
* GPS data going to Influx, however, is still an epoch time in GMT.
 