### PR TITLE
feat: dbc messages for heartbeats

### DIFF
--- a/dbc/brightside.dbc
+++ b/dbc/brightside.dbc
@@ -33,7 +33,7 @@ NS_ :
 
 BS_:
 
-BU_: AMB BMS DID ECU MDU MCB TEL OBC MEMORATOR
+BU_: AMB BMS DID ECU MDU MCB TEL OBC MEMORATOR VDS
 
 
 BO_ 1793 VoltageSensorsData: 8 AMB
@@ -438,11 +438,39 @@ BO_ 1880 GPSSideCount: 8 TEL
  SG_ Lonside : 8|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ SatelliteCount : 16|32@1+ (1,0) [0|100] "" Vector__XXX
 
-BO_ 1872 TELDiagnostics: 1 TEL
+BO_ 521 TELHeartbeat: 8 TEL
  SG_ RTCReset : 0|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ GPSFix : 1|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ IMUFail : 2|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ WatchdogReset : 3|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ TELRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 513 AMBHeartbeat: 8 AMB
+ SG_ AMBRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 514 BMSHeartbeat: 8 BMS
+ SG_ BMSRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 515 DIDheartbeat: 8 DID
+ SG_ DIDRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 516 ECUHeartbeat: 8 ECU
+ SG_ ECURuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 517 OBCHeartbeat: 8 OBC
+ SG_ OBCRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 518 MDUHeartbeat: 8 MDU
+ SG_ MDURuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 519 MCBHeartbeat: 8 MCB
+ SG_ MCBRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 520 MEMORATORHeartbeat: 8 MEMORATOR
+ SG_ MEMORATORRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 522 VDSHeartbeat: 8 VDS
+ SG_ VDSRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
 
 
@@ -577,12 +605,6 @@ CM_ SG_ 1028 PedalADCOutOfRange "1 if true 0 if false";
 CM_ SG_ 1028 RegenEnabled "1 if true 0 if false";
 CM_ SG_ 1028 CruiseControlEnabled "1 if true 0 if false";
 CM_ SG_ 1028 MechBrakePressed "1 if pressed 0 if not pressed";
-CM_ SG_ 1873 Second "Seconds from RTC inside Kvaser Memorator 2xHS v2";
-CM_ SG_ 1873 Minute "Minutes from RTC inside Kvaser Memorator 2xHS v2";
-CM_ SG_ 1873 Hour "Hours from RTC inside Kvaser Memorator 2xHS v2";
-CM_ SG_ 1873 Day "Days from RTC inside Kvaser Memorator 2xHS v2";
-CM_ SG_ 1873 Month "Months from RTC inside Kvaser Memorator 2xHS v2";
-CM_ SG_ 1873 Year "Years from RTC inside Kvaser Memorator 2xHS v2";
 BA_DEF_  "BusType" STRING ;
 BA_DEF_DEF_  "BusType" "CAN";
 SIG_VALTYPE_ 1793 VoltSensor1 : 1;

--- a/dbc/brightside.dbc
+++ b/dbc/brightside.dbc
@@ -438,38 +438,35 @@ BO_ 1880 GPSSideCount: 8 TEL
  SG_ Lonside : 8|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ SatelliteCount : 16|32@1+ (1,0) [0|100] "" Vector__XXX
 
-BO_ 521 TELHeartbeat: 8 TEL
+BO_ 777 TELDiagnostic: 8 TEL
  SG_ RTCReset : 0|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ GPSFix : 1|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ IMUFail : 2|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ WatchdogReset : 3|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ TELRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 513 AMBHeartbeat: 8 AMB
+BO_ 769 AMBDiagnostic: 8 AMB
  SG_ AMBRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 514 BMSHeartbeat: 8 BMS
+BO_ 770 BMSDiagnostic: 8 BMS
  SG_ BMSRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 515 DIDheartbeat: 8 DID
+BO_ 771 DIDDiagnostic: 8 DID
  SG_ DIDRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 516 ECUHeartbeat: 8 ECU
+BO_ 772 ECUDiagnostic: 8 ECU
  SG_ ECURuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 517 OBCHeartbeat: 8 OBC
- SG_ OBCRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
-
-BO_ 518 MDUHeartbeat: 8 MDU
+BO_ 773 MDUDiagnostic: 8 MDU
  SG_ MDURuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 519 MCBHeartbeat: 8 MCB
+BO_ 774 MCBDiagnostic: 8 MCB
  SG_ MCBRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 520 MEMORATORHeartbeat: 8 MEMORATOR
+BO_ 775 MEMORATORDiagnostic: 8 MEMORATOR
  SG_ MEMORATORRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 522 VDSHeartbeat: 8 VDS
+BO_ 776 VDSDiagnostic: 8 VDS
  SG_ VDSRuntimeCounter : 48|16@1+ (1,0) [0|0] "" Vector__XXX
 
 


### PR DESCRIPTION
**Change**:
* To match the CAN ID table and to support the changes for heartbeat messages, the DBC was updated so 0x201 to 0x30A are the diagnostic messages for each board. Note that diagnostic and heartbeat are used interchangeably here because the board's heartbeat contains diagnostic information (most notably the runtime counter).
* Now the TEL diagnostic message ID went from 0x750 to 0x309.