### PR TITLE
Fix: Correcred datasources and buckets

### DIFF
--- a/dashboards/BrightSide's Test Telemetry-1696718747966.json
+++ b/dashboards/BrightSide's Test Telemetry-1696718747966.json
@@ -87,7 +87,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -328,7 +328,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"Faults\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SlaveBoardComm\" or r[\"_field\"] == \"BMSSelfTest\" or r[\"_field\"] == \"OverTemp\" or r[\"_field\"] == \"UnderVoltage\" or r[\"_field\"] == \"OverVoltage\" or r[\"_field\"] == \"IsoLost\" or r[\"_field\"] == \"ChargeOvercurrent\" or r[\"_field\"] == \"VoltOutofRange\" or r[\"_field\"] == \"TempOutofRange\" or r[\"_field\"] == \"PackBalancingActive\" or r[\"_field\"] == \"LLIMActive\" or r[\"_field\"] == \"HLIMActive\" or r[\"_field\"] == \"ChargeOverTemp\" or r[\"_field\"] == \"RequestRegenOff\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -340,7 +340,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -474,7 +474,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"Faults\")\n  |> filter(fn: (r) => r[\"_field\"] == \"LowVoltage\" or r[\"_field\"] == \"HighVoltage\" or r[\"_field\"] == \"LowTemp\" or r[\"_field\"] == \"HighTemp\" or r[\"_field\"] == \"NoECUCurrentMessage\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -486,7 +486,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -571,7 +571,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"BalancingStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ModuleStatusofBits\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -596,7 +596,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -687,7 +687,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofHighest\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -699,7 +699,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -750,7 +750,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofHighest\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -762,7 +762,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -853,7 +853,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofLeast\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -865,7 +865,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -916,7 +916,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofLeast\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -928,7 +928,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -978,7 +978,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"IndexofHighestModule\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -990,7 +990,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1040,7 +1040,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"IndexofLowestModule\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1052,7 +1052,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1143,7 +1143,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TotalPackVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1155,7 +1155,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1246,7 +1246,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUCurrentStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"PackCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1258,7 +1258,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1349,7 +1349,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUCurrentStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"LVCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1374,7 +1374,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1462,7 +1462,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"PackHealth\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SOC\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1474,7 +1474,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1525,7 +1525,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"PackHealth\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SOC\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1550,7 +1550,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1991,7 +1991,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"ModuleVoltages\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Voltage1\" or r[\"_field\"] == \"Voltage2\" or r[\"_field\"] == \"Voltage3\" or r[\"_field\"] == \"Voltage4\" or r[\"_field\"] == \"Voltage5\"or r[\"_field\"] == \"Voltage6\" or r[\"_field\"] == \"Voltage7\" or r[\"_field\"] == \"Voltage8\" or r[\"_field\"] == \"Voltage9\" or r[\"_field\"] == \"Voltage10\" or r[\"_field\"] == \"Voltage11\" or r[\"_field\"] == \"Voltage12\" or r[\"_field\"] == \"Voltage13\" or r[\"_field\"] == \"Voltage14\" or r[\"_field\"] == \"Voltage15\"or r[\"_field\"] == \"Voltage16\" or r[\"_field\"] == \"Voltage17\" or r[\"_field\"] == \"Voltage18\" or r[\"_field\"] == \"Voltage19\" or r[\"_field\"] == \"Voltage20\" or r[\"_field\"] == \"Voltage21\" or r[\"_field\"] == \"Voltage22\" or r[\"_field\"] == \"Voltage23\" or r[\"_field\"] == \"Voltage24\" or r[\"_field\"] == \"Voltage25\"or r[\"_field\"] == \"Voltage26\" or r[\"_field\"] == \"Voltage27\" or r[\"_field\"] == \"Voltage28\" or r[\"_field\"] == \"Voltage29\" or r[\"_field\"] == \"Voltage30\" or r[\"_field\"] == \"Voltage31\" or r[\"_field\"] == \"Voltage32\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2004,7 +2004,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2445,7 +2445,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"ModuleTemps\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Temp1\" or r[\"_field\"] == \"Temp2\" or r[\"_field\"] == \"Temp3\" or r[\"_field\"] == \"Temp4\" or r[\"_field\"] == \"Temp5\"or r[\"_field\"] == \"Temp6\" or r[\"_field\"] == \"Temp7\" or r[\"_field\"] == \"Temp8\" or r[\"_field\"] == \"Temp9\" or r[\"_field\"] == \"Temp10\" or r[\"_field\"] == \"Temp11\" or r[\"_field\"] == \"Temp12\" or r[\"_field\"] == \"Temp13\" or r[\"_field\"] == \"Temp14\" or r[\"_field\"] == \"Temp15\"or r[\"_field\"] == \"Temp16\" or r[\"_field\"] == \"Temp17\" or r[\"_field\"] == \"Temp18\" or r[\"_field\"] == \"Temp19\" or r[\"_field\"] == \"Temp20\" or r[\"_field\"] == \"Temp21\" or r[\"_field\"] == \"Temp22\" or r[\"_field\"] == \"Temp23\" or r[\"_field\"] == \"Temp24\" or r[\"_field\"] == \"Temp25\"or r[\"_field\"] == \"Temp26\" or r[\"_field\"] == \"Temp27\" or r[\"_field\"] == \"Temp28\" or r[\"_field\"] == \"Temp29\" or r[\"_field\"] == \"Temp30\" or r[\"_field\"] == \"Temp31\" or r[\"_field\"] == \"Temp32\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"

--- a/dashboards/Brightside's BMS-1708206910017.json
+++ b/dashboards/Brightside's BMS-1708206910017.json
@@ -51,7 +51,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -292,7 +292,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"Faults\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SlaveBoardComm\" or r[\"_field\"] == \"BMSSelfTest\" or r[\"_field\"] == \"OverTemp\" or r[\"_field\"] == \"UnderVoltage\" or r[\"_field\"] == \"OverVoltage\" or r[\"_field\"] == \"IsoLost\" or r[\"_field\"] == \"ChargeOvercurrent\" or r[\"_field\"] == \"VoltOutofRange\" or r[\"_field\"] == \"TempOutofRange\" or r[\"_field\"] == \"PackBalancingActive\" or r[\"_field\"] == \"LLIMActive\" or r[\"_field\"] == \"HLIMActive\" or r[\"_field\"] == \"ChargeOverTemp\" or r[\"_field\"] == \"RequestRegenOff\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -304,7 +304,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -437,7 +437,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"Faults\")\n  |> filter(fn: (r) => r[\"_field\"] == \"LowVoltage\" or r[\"_field\"] == \"HighVoltage\" or r[\"_field\"] == \"LowTemp\" or r[\"_field\"] == \"HighTemp\" or r[\"_field\"] == \"NoECUCurrentMessage\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -449,7 +449,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "description": "",
       "fieldConfig": {
@@ -500,7 +500,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"ESTOP_Pressed\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -525,7 +525,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -618,7 +618,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofHighest\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -630,7 +630,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -681,7 +681,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofHighest\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -693,7 +693,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -786,7 +786,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofLeast\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -798,7 +798,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -849,7 +849,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VoltageofLeast\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -861,7 +861,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -911,7 +911,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"IndexofHighestModule\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -923,7 +923,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -973,7 +973,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"IndexofLowestModule\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -985,7 +985,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1078,7 +1078,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TotalPackVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1090,7 +1090,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1141,7 +1141,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"VoltageSummary\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TotalPackVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1153,7 +1153,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1246,7 +1246,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"PackCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1258,7 +1258,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1309,7 +1309,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"PackCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1334,7 +1334,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1777,7 +1777,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"ModuleVoltages\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Voltage1\" or r[\"_field\"] == \"Voltage2\" or r[\"_field\"] == \"Voltage3\" or r[\"_field\"] == \"Voltage4\" or r[\"_field\"] == \"Voltage5\"or r[\"_field\"] == \"Voltage6\" or r[\"_field\"] == \"Voltage7\" or r[\"_field\"] == \"Voltage8\" or r[\"_field\"] == \"Voltage9\" or r[\"_field\"] == \"Voltage10\" or r[\"_field\"] == \"Voltage11\" or r[\"_field\"] == \"Voltage12\" or r[\"_field\"] == \"Voltage13\" or r[\"_field\"] == \"Voltage14\" or r[\"_field\"] == \"Voltage15\"or r[\"_field\"] == \"Voltage16\" or r[\"_field\"] == \"Voltage17\" or r[\"_field\"] == \"Voltage18\" or r[\"_field\"] == \"Voltage19\" or r[\"_field\"] == \"Voltage20\" or r[\"_field\"] == \"Voltage21\" or r[\"_field\"] == \"Voltage22\" or r[\"_field\"] == \"Voltage23\" or r[\"_field\"] == \"Voltage24\" or r[\"_field\"] == \"Voltage25\"or r[\"_field\"] == \"Voltage26\" or r[\"_field\"] == \"Voltage27\" or r[\"_field\"] == \"Voltage28\" or r[\"_field\"] == \"Voltage29\" or r[\"_field\"] == \"Voltage30\" or r[\"_field\"] == \"Voltage31\" or r[\"_field\"] == \"Voltage32\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1790,7 +1790,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2233,7 +2233,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"ModuleTemps\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Temp1\" or r[\"_field\"] == \"Temp2\" or r[\"_field\"] == \"Temp3\" or r[\"_field\"] == \"Temp4\" or r[\"_field\"] == \"Temp5\"or r[\"_field\"] == \"Temp6\" or r[\"_field\"] == \"Temp7\" or r[\"_field\"] == \"Temp8\" or r[\"_field\"] == \"Temp9\" or r[\"_field\"] == \"Temp10\" or r[\"_field\"] == \"Temp11\" or r[\"_field\"] == \"Temp12\" or r[\"_field\"] == \"Temp13\" or r[\"_field\"] == \"Temp14\" or r[\"_field\"] == \"Temp15\"or r[\"_field\"] == \"Temp16\" or r[\"_field\"] == \"Temp17\" or r[\"_field\"] == \"Temp18\" or r[\"_field\"] == \"Temp19\" or r[\"_field\"] == \"Temp20\" or r[\"_field\"] == \"Temp21\" or r[\"_field\"] == \"Temp22\" or r[\"_field\"] == \"Temp23\" or r[\"_field\"] == \"Temp24\" or r[\"_field\"] == \"Temp25\"or r[\"_field\"] == \"Temp26\" or r[\"_field\"] == \"Temp27\" or r[\"_field\"] == \"Temp28\" or r[\"_field\"] == \"Temp29\" or r[\"_field\"] == \"Temp30\" or r[\"_field\"] == \"Temp31\" or r[\"_field\"] == \"Temp32\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2246,7 +2246,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2685,7 +2685,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"BalancingStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Mod1_BalActive\" or r[\"_field\"] == \"Mod2_BalActive\" or r[\"_field\"] == \"Mod3_BalActive\" or r[\"_field\"] == \"Mod4_BalActive\" or r[\"_field\"] == \"Mod5_BalActive\"or r[\"_field\"] == \"Mod6_BalActive\" or r[\"_field\"] == \"Mod7_BalActive\" or r[\"_field\"] == \"Mod8_BalActive\" or r[\"_field\"] == \"Mod9_BalActive\" or r[\"_field\"] == \"Mod10_BalActive\" or r[\"_field\"] == \"Mod11_BalActive\" or r[\"_field\"] == \"Mod12_BalActive\" or r[\"_field\"] == \"Mod13_BalActive\" or r[\"_field\"] == \"Mod14_BalActive\" or r[\"_field\"] == \"Mod15_BalActive\"or r[\"_field\"] == \"Mod16_BalActive\" or r[\"_field\"] == \"Mod17_BalActive\" or r[\"_field\"] == \"Mod18_BalActive\" or r[\"_field\"] == \"Mod19_BalActive\" or r[\"_field\"] == \"Mod20_BalActive\" or r[\"_field\"] == \"Mod21_BalActive\" or r[\"_field\"] == \"Mod22_BalActive\" or r[\"_field\"] == \"Mod23_BalActive\" or r[\"_field\"] == \"Mod24_BalActive\" or r[\"_field\"] == \"Mod25_BalActive\"or r[\"_field\"] == \"Mod26_BalActive\" or r[\"_field\"] == \"Mod27_BalActive\" or r[\"_field\"] == \"Mod28_BalActive\" or r[\"_field\"] == \"Mod29_BalActive\" or r[\"_field\"] == \"Mod30_BalActive\" or r[\"_field\"] == \"Mod31_BalActive\" or r[\"_field\"] == \"Mod32_BalActive\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2698,7 +2698,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "description": "",
       "fieldConfig": {
@@ -2750,7 +2750,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SuppBattVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2775,7 +2775,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2863,7 +2863,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"PackHealth\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SOC\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2875,7 +2875,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2926,7 +2926,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"PackHealth\")\n  |> filter(fn: (r) => r[\"_field\"] == \"SOC\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2938,7 +2938,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3030,7 +3030,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"ECU\")\n  |> filter(fn: (r) => r[\"class\"] == \"ECUStatus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"LVCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"

--- a/dashboards/Brightside's PAS-1709602334016.json
+++ b/dashboards/Brightside's PAS-1709602334016.json
@@ -292,9 +292,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"StatusInfo\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\" or r[\"_field\"] == \"Velocity\" or r[\"_field\"] == \"BusCurrent\" or r[\"_field\"] == \"BusVoltUpperLim\" or r[\"_field\"] == \"BusVoltLowerLim\" or r[\"_field\"] == \"HeadsinkTemp\" or r[\"_field\"] == \"HardwareOverCurrent\" or r[\"_field\"] == \"SoftwareOverCurrent\" or r[\"_field\"] == \"DCBusOverVoltage\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"StatusInfo\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\" or r[\"_field\"] == \"Velocity\" or r[\"_field\"] == \"BusCurrent\" or r[\"_field\"] == \"BusVoltUpperLim\" or r[\"_field\"] == \"BusVoltLowerLim\" or r[\"_field\"] == \"HeadsinkTemp\" or r[\"_field\"] == \"HardwareOverCurrent\" or r[\"_field\"] == \"SoftwareOverCurrent\" or r[\"_field\"] == \"DCBusOverVoltage\")\n  |> sample(n: 10, pos: 1)\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -381,9 +381,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -486,9 +486,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -562,9 +562,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -638,9 +638,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VehicleVelocity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"VehicleVelocity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -743,9 +743,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -819,9 +819,9 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
-          "query": "from(bucket: \"CAN\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\n  |> filter(fn: (r) => r[\"_field\"] == \"BusCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],

--- a/dashboards/Daybreak Telemetry-1687752576292.json
+++ b/dashboards/Daybreak Telemetry-1687752576292.json
@@ -343,7 +343,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -368,7 +368,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -521,7 +521,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"class\"] == \"motor_state\")\n  |> filter(fn: (r) => r[\"_field\"] == \"bridge_pwm_flag\" or r[\"_field\"] == \"motor_current_flag\" or r[\"_field\"] == \"velocity_flag\" or r[\"_field\"] == \"bus_current_flag\" or r[\"_field\"] == \"bus_voltage_lower_limit_flag\" or r[\"_field\"] == \"bus_voltage_upper_limit_flag\" or r[\"_field\"] == \"heat_sink_temp_flag\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -533,7 +533,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -686,7 +686,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"class\"] == \"motor_state\")\n  |> filter(fn: (r) => r[\"_field\"] == \"watchdog_reset\" or r[\"_field\"] == \"undervoltage_lockout\" or r[\"_field\"] == \"sw_overcurrent\" or r[\"_field\"] == \"hw_overcurrent\" or r[\"_field\"] == \"dc_bus_overvoltage\" or r[\"_field\"] == \"config_read_error\" or r[\"_field\"] == \"bad_hall_sequence\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -699,7 +699,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -715,7 +715,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -808,7 +808,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_velocity\")\r\n  |> map(fn: (r) => ({r with _value: r._value * -1.0}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -820,7 +820,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -913,7 +913,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\r\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -926,7 +926,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -942,7 +942,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1022,7 +1022,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1034,7 +1034,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1114,7 +1114,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_current\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1127,7 +1127,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -1143,7 +1143,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1234,7 +1234,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1246,7 +1246,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1337,7 +1337,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"heatsink_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1350,7 +1350,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -1366,7 +1366,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1485,7 +1485,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"contactor_k1\" or r[\"_field\"] == \"contactor_k2\" or r[\"_field\"] == \"contactor_k3\"\r\nor r[\"_field\"] == \"fault_state\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1497,7 +1497,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1549,7 +1549,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"startup_time\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1561,7 +1561,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1611,7 +1611,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"fault_code\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1623,7 +1623,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1788,7 +1788,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"source_power\" or r[\"_field\"] == \"load_power\" or r[\"_field\"] == \"interlock_tripped\" or r[\"_field\"] == \"hard_wire_contactor_request\" or r[\"_field\"] == \"can_contactor_request\" or r[\"_field\"] == \"llim_set\" or r[\"_field\"] == \"hlim_set\" or r[\"_field\"] == \"fan_on\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1800,7 +1800,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1965,7 +1965,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"over_voltage\" or r[\"_field\"] == \"under_voltage\" or r[\"_field\"] == \"over_temperature\" or r[\"_field\"] == \"discharge_overcurrent\" or r[\"_field\"] == \"charge_overcurrent\" or r[\"_field\"] == \"communication_fault\" or r[\"_field\"] == \"interlock_tripped\" or r[\"_field\"] == \"driving_off\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1977,7 +1977,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2118,7 +2118,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"isolation_fault_warn\" or r[\"_field\"] == \"hot_temperature_warn\" or r[\"_field\"] == \"cold_temperature_warn\" or r[\"_field\"] == \"low_soh_warn\" or r[\"_field\"] == \"discharge_overcurrent_warn\" or r[\"_field\"] == \"charge_overcurrent_warn\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2131,7 +2131,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2147,7 +2147,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2235,7 +2235,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_metadata\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"state_of_charge\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2248,7 +2248,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2264,7 +2264,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2352,7 +2352,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2364,7 +2364,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2456,7 +2456,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2468,7 +2468,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2518,7 +2518,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_temperature_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2530,7 +2530,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2621,7 +2621,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2633,7 +2633,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2679,7 +2679,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_temperature_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2692,7 +2692,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2708,7 +2708,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2800,7 +2800,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_current\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2812,7 +2812,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2903,7 +2903,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"charge_limit\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2915,7 +2915,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3007,7 +3007,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"discharge_limit\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3020,7 +3020,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -3036,7 +3036,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3125,7 +3125,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3137,7 +3137,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3235,7 +3235,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3247,7 +3247,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3293,7 +3293,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_voltage_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3305,7 +3305,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3396,7 +3396,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3408,7 +3408,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3454,7 +3454,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Telemetry\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_voltage_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3476,7 +3476,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3603,7 +3603,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")\n\n  from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
               "refId": "A"
@@ -3615,7 +3615,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3731,7 +3731,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "hide": false,
               "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")\n\n  from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
@@ -3744,7 +3744,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3865,7 +3865,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")",
               "refId": "A"
@@ -3873,7 +3873,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "hide": false,
               "query": "from(bucket: \"Telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_current\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")",

--- a/dashboards/Daybreak Test Telemetry-1687754030436.json
+++ b/dashboards/Daybreak Test Telemetry-1687754030436.json
@@ -343,7 +343,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -368,7 +368,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -521,7 +521,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"class\"] == \"motor_state\")\n  |> filter(fn: (r) => r[\"_field\"] == \"bridge_pwm_flag\" or r[\"_field\"] == \"motor_current_flag\" or r[\"_field\"] == \"velocity_flag\" or r[\"_field\"] == \"bus_current_flag\" or r[\"_field\"] == \"bus_voltage_lower_limit_flag\" or r[\"_field\"] == \"bus_voltage_upper_limit_flag\" or r[\"_field\"] == \"heat_sink_temp_flag\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -533,7 +533,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -686,7 +686,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"class\"] == \"motor_state\")\n  |> filter(fn: (r) => r[\"_field\"] == \"watchdog_reset\" or r[\"_field\"] == \"undervoltage_lockout\" or r[\"_field\"] == \"sw_overcurrent\" or r[\"_field\"] == \"hw_overcurrent\" or r[\"_field\"] == \"dc_bus_overvoltage\" or r[\"_field\"] == \"config_read_error\" or r[\"_field\"] == \"bad_hall_sequence\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -699,7 +699,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -715,7 +715,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -808,7 +808,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_velocity\")\r\n  |> map(fn: (r) => ({r with _value: r._value * -1.0}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -820,7 +820,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -913,7 +913,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\r\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -926,7 +926,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -942,7 +942,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1022,7 +1022,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1034,7 +1034,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1114,7 +1114,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_current\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1127,7 +1127,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -1143,7 +1143,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1234,7 +1234,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1246,7 +1246,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1337,7 +1337,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"heatsink_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1350,7 +1350,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -1366,7 +1366,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1485,7 +1485,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"contactor_k1\" or r[\"_field\"] == \"contactor_k2\" or r[\"_field\"] == \"contactor_k3\"\r\nor r[\"_field\"] == \"fault_state\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1497,7 +1497,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1549,7 +1549,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"startup_time\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1561,7 +1561,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1611,7 +1611,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"fault_code\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1623,7 +1623,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1788,7 +1788,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"source_power\" or r[\"_field\"] == \"load_power\" or r[\"_field\"] == \"interlock_tripped\" or r[\"_field\"] == \"hard_wire_contactor_request\" or r[\"_field\"] == \"can_contactor_request\" or r[\"_field\"] == \"llim_set\" or r[\"_field\"] == \"hlim_set\" or r[\"_field\"] == \"fan_on\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1800,7 +1800,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1965,7 +1965,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"over_voltage\" or r[\"_field\"] == \"under_voltage\" or r[\"_field\"] == \"over_temperature\" or r[\"_field\"] == \"discharge_overcurrent\" or r[\"_field\"] == \"charge_overcurrent\" or r[\"_field\"] == \"communication_fault\" or r[\"_field\"] == \"interlock_tripped\" or r[\"_field\"] == \"driving_off\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1977,7 +1977,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2118,7 +2118,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_state\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"isolation_fault_warn\" or r[\"_field\"] == \"hot_temperature_warn\" or r[\"_field\"] == \"cold_temperature_warn\" or r[\"_field\"] == \"low_soh_warn\" or r[\"_field\"] == \"discharge_overcurrent_warn\" or r[\"_field\"] == \"charge_overcurrent_warn\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2131,7 +2131,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2147,7 +2147,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2235,7 +2235,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_metadata\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"state_of_charge\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2248,7 +2248,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2264,7 +2264,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2352,7 +2352,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2364,7 +2364,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2456,7 +2456,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2468,7 +2468,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2518,7 +2518,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_temperature_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2530,7 +2530,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2621,7 +2621,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_temperature\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2633,7 +2633,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2679,7 +2679,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_temperatures\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_temperature_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2692,7 +2692,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -2708,7 +2708,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2800,7 +2800,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_current\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2812,7 +2812,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2903,7 +2903,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"charge_limit\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -2915,7 +2915,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3007,7 +3007,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_currents\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"discharge_limit\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3020,7 +3020,7 @@
       "collapsed": false,
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "gridPos": {
         "h": 1,
@@ -3036,7 +3036,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3125,7 +3125,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"pack_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3137,7 +3137,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3235,7 +3235,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3247,7 +3247,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3293,7 +3293,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"max_voltage_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3305,7 +3305,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3396,7 +3396,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_voltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3408,7 +3408,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -3454,7 +3454,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"Test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_bms\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"battery_voltages\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"min_voltage_idx\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -3476,7 +3476,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3604,7 +3604,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"motor_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")\n\n  from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"motor\")\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
               "refId": "A"
@@ -3616,7 +3616,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3733,7 +3733,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "hide": false,
               "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")\n\n  from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"vehicle_velocity\")\n  |> map(fn: (r) => ({r with _value: r._value * -1.0 * 3.6}))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
@@ -3746,7 +3746,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "fieldConfig": {
             "defaults": {
@@ -3868,7 +3868,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"speed_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"current_setpoint\")\n  |> filter(fn: (r) => r[\"car\"] == \"Daybreak\")\n  |> filter(fn: (r) => r[\"class\"] == \"drive_command\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")",
               "refId": "A"
@@ -3876,7 +3876,7 @@
             {
               "datasource": {
                 "type": "influxdb",
-                "uid": "o2uhkwje8832ha"
+                "uid": "P951FEA4DE68E13C5"
               },
               "hide": false,
               "query": "from(bucket: \"Test\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"daybreak_motor_controller\")\n  |> filter(fn: (r) => r[\"_field\"] == \"bus_current\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"last\")",

--- a/dashboards/Motor Dashboard-1710561145018.json
+++ b/dashboards/Motor Dashboard-1710561145018.json
@@ -38,7 +38,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -115,7 +115,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"StatusInfo\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\" or r[\"_field\"] == \"Velocity\" or r[\"_field\"] == \"BusCurrent\" or r[\"_field\"] == \"BusVoltUpperLim\" or r[\"_field\"] == \"BusVoltLowerLim\" or r[\"_field\"] == \"HeadsinkTemp\" or r[\"_field\"] == \"HardwareOverCurrent\" or r[\"_field\"] == \"SoftwareOverCurrent\" or r[\"_field\"] == \"DCBusOverVoltage\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -140,7 +140,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -217,7 +217,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -229,7 +229,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -306,7 +306,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -318,7 +318,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -395,7 +395,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -407,7 +407,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -484,7 +484,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"VehicleVelocity\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -496,7 +496,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -573,7 +573,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -585,7 +585,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -662,7 +662,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"BusVoltage\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -674,7 +674,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -751,7 +751,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"BusMeasurement\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"BusCurrent\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"

--- a/dashboards/Pit Crew Dashboard-1711352544498.json
+++ b/dashboards/Pit Crew Dashboard-1711352544498.json
@@ -38,7 +38,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "description": "",
       "fieldConfig": {
@@ -89,7 +89,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\n  |> filter(fn: (r) => r[\"_field\"] == \"DriveState\")\n  |> filter(fn: (r) => r[\"class\"] == \"DriverInterface\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -114,7 +114,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -192,7 +192,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -204,7 +204,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -255,7 +255,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -267,7 +267,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -345,7 +345,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -357,7 +357,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -408,7 +408,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorVelocity\")\n  |> filter(fn: (r) => r[\"class\"] == \"VelocityMeasurement\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -420,7 +420,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -499,7 +499,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorTemp\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"SinkMotorTempMeas\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -511,7 +511,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -562,7 +562,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorTemp\")\n  |> filter(fn: (r) => r[\"class\"] == \"SinkMotorTempMeas\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -574,7 +574,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -652,7 +652,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -664,7 +664,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -715,7 +715,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MCB\")\n  |> filter(fn: (r) => r[\"class\"] == \"MotorDriveCommand\")\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -727,7 +727,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -778,7 +778,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"MDU\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"StatusInfo\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"MotorCurrent\" or r[\"_field\"] == \"Velocity\" or r[\"_field\"] == \"BusCurrent\" or r[\"_field\"] == \"BusVoltUpperLim\" or r[\"_field\"] == \"BusVoltLowerLim\" or r[\"_field\"] == \"HeadsinkTemp\" or r[\"_field\"] == \"HardwareOverCurrent\" or r[\"_field\"] == \"SoftwareOverCurrent\" or r[\"_field\"] == \"DCBusOverVoltage\")\r\n  |> sample(n: 10, pos: 1)\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -803,7 +803,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -882,7 +882,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"TEL\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"SimulationSpeed\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"SimulationSpeedRec\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -894,7 +894,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -945,7 +945,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"TEL\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"SimulationSpeed\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"SimulationSpeedRec\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -957,7 +957,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1008,7 +1008,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"IMU_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"IMU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"X\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"A\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -1020,7 +1020,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1071,7 +1071,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"IMU_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"IMU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"X\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"A\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -1083,7 +1083,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1134,7 +1134,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"IMU_prod\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"IMU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Z\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"A\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"
@@ -1159,7 +1159,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -1602,7 +1602,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"BMS\")\n  |> filter(fn: (r) => r[\"class\"] == \"ModuleTemps\")\n  |> filter(fn: (r) => r[\"_field\"] == \"Temp1\" or r[\"_field\"] == \"Temp2\" or r[\"_field\"] == \"Temp3\" or r[\"_field\"] == \"Temp4\" or r[\"_field\"] == \"Temp5\"or r[\"_field\"] == \"Temp6\" or r[\"_field\"] == \"Temp7\" or r[\"_field\"] == \"Temp8\" or r[\"_field\"] == \"Temp9\" or r[\"_field\"] == \"Temp10\" or r[\"_field\"] == \"Temp11\" or r[\"_field\"] == \"Temp12\" or r[\"_field\"] == \"Temp13\" or r[\"_field\"] == \"Temp14\" or r[\"_field\"] == \"Temp15\"or r[\"_field\"] == \"Temp16\" or r[\"_field\"] == \"Temp17\" or r[\"_field\"] == \"Temp18\" or r[\"_field\"] == \"Temp19\" or r[\"_field\"] == \"Temp20\" or r[\"_field\"] == \"Temp21\" or r[\"_field\"] == \"Temp22\" or r[\"_field\"] == \"Temp23\" or r[\"_field\"] == \"Temp24\" or r[\"_field\"] == \"Temp25\"or r[\"_field\"] == \"Temp26\" or r[\"_field\"] == \"Temp27\" or r[\"_field\"] == \"Temp28\" or r[\"_field\"] == \"Temp29\" or r[\"_field\"] == \"Temp30\" or r[\"_field\"] == \"Temp31\" or r[\"_field\"] == \"Temp32\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -1615,7 +1615,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -2058,7 +2058,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_prod\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"AMB\")\n  |> filter(fn: (r) => r[\"_field\"] == \"TempSensors1\" or r[\"_field\"] == \"TempSensors2\" or r[\"_field\"] == \"TempSensors3\" or r[\"_field\"] == \"TempSensors4\" or r[\"_field\"] == \"TempSensors5\" or r[\"_field\"] == \"TempSensors6\" or r[\"_field\"] == \"TempSensors7\" or r[\"_field\"] == \"TempSensors8\")\n  |> filter(fn: (r) => r[\"class\"] == \"TempSensorsData\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"

--- a/dashboards/Test for CAN, GPS, IMU Messages-1708396488142.json
+++ b/dashboards/Test for CAN, GPS, IMU Messages-1708396488142.json
@@ -121,7 +121,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "description": "",
       "fieldConfig": {
@@ -199,7 +199,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"CAN_test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"AMB\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"TempSensors1\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"TempSensorsData\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -301,7 +301,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "description": "",
       "fieldConfig": {
@@ -379,7 +379,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"GPS_test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"GPS\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Latitude\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\r\n  |> yield(name: \"last\")",
           "refId": "A"
@@ -482,7 +482,7 @@
     {
       "datasource": {
         "type": "influxdb",
-        "uid": "o2uhkwje8832ha"
+        "uid": "P951FEA4DE68E13C5"
       },
       "fieldConfig": {
         "defaults": {
@@ -559,7 +559,7 @@
         {
           "datasource": {
             "type": "influxdb",
-            "uid": "o2uhkwje8832ha"
+            "uid": "P951FEA4DE68E13C5"
           },
           "query": "from(bucket: \"IMU_test\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"IMU\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"X\")\r\n  |> filter(fn: (r) => r[\"class\"] == \"A\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> yield(name: \"mean\")",
           "refId": "A"

--- a/templates/template_dotenv.env
+++ b/templates/template_dotenv.env
@@ -16,7 +16,8 @@ MESSAGE_TYPES="CAN,GPS,IMU"
 INFLUX_INIT_BUCKET="Init_test"
 INFLUX_DEBUG_BUCKET="CAN_test"
 
-DS_INFLUXDB="o2uhkwje8832ha"
+# Influx Datasource
+DS_INFLUXDB="P951FEA4DE68E13C5"
 
 # Parser secret key
 


### PR DESCRIPTION
Grafana dashboards were not loading properly upon starting Sunlink. We would see: 

> Datasource "---" not found

errors. Editing each panel and saving it would fix the issue, but this is tedious and who wants to do this every time the dashboard is reloaded. 

After looking through the json of each of the dashboards carefully, I found that the uid's did not match. I experimented with creating a new dashboard and found the UID created there was similar to what was in the json's of the BMS dashboard a long time ago (this commit and earlier: https://github.com/UBC-Solar/sunlink/commit/ba9336068081ce0857a21ecf55ec4b0eac3d923e). So I changed all the uid's back to this and it worked!

Also updated the PAS dashboard source bucket to be CAN_prod instead of CAN which is outdated. 