### PR TITLE
Fix: Memorator Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Here are some example invocations:
 
 ## Running the Offline Log Uploader
 
-The offline log uploader will use the `MemoratorUploader` script in the `tools/` folder to read the contents of the SD card on the Memorator and then upload those messages to InfluxDB. There are two options for this: `-u fast` and `-u all`. `-u fast` will only upload one Log File Container (1 .KMF file will be read). In `-u all` all 15 .KMF files on the SD card will be read and their data will be uploaded.
+The offline log uploader will use the `MemoratorUploader` script in the `tools/` folder to read the contents of the SD card on the Memorator and then upload those messages to InfluxDB. There are two options for this: `-u fast` and `-u all`. `-u fast` will only upload one Log File Container (1 .KMF file will be read). In `-u all` all 15 .KMF files on the SD card will be read and their data will be uploaded. Note: data is sent to the `_log` suffixed bucket.
 
 ```bash
 ./link_telemetry.py -u fast

--- a/README.md
+++ b/README.md
@@ -475,10 +475,11 @@ Here are some example invocations:
 
 ## Running the Offline Log Uploader
 
-To run the offline log uploader the `logfiles` folder should have a generated log file to read and request the parser to write to InfluxDB in the specified buckets (_test or _prod based on --debug or --prod options respectively). To do this use the -u (--log-upload) flag as follows:
+The offline log uploader will use the `MemoratorUploader` script in the `tools/` folder to read the contents of the SD card on the Memorator and then upload those messages to InfluxDB. There are two options for this: `-u fast` and `-u all`. `-u fast` will only upload one Log File Container (1 .KMF file will be read). In `-u all` all 15 .KMF files on the SD card will be read and their data will be uploaded.
 
 ```bash
-./link_telemetry.py -u
+./link_telemetry.py -u fast
+./link_telemetry.py -u all
 ```
 
 ## Running the tests

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -562,6 +562,9 @@ def main():
     source_group.add_argument("--dbc", action="store",
                               help="Specifies the dbc file to use. For example: ./dbc/brightside.dbc"
                               "Default: ./dbc/brightside.dbc")
+    
+    source_group.add_argument("--fast-u", action="store_true",
+                            help=("Same as -u but will only do 1 of the 15 Log containers"))
 
     source_group.add_argument("-f", "--frequency-hz", action="store", default=DEFAULT_RANDOM_FREQUENCY_HZ, type=int,
                               help=((f"Specifies the frequency (in Hz) for random message generation. \
@@ -672,10 +675,12 @@ def main():
     
     if args.log_upload:
         upload_logs(args, live_filters, log_filters, display_filters, LOG_WRITE_ENDPOINT)
-        return 0
+        print(f"{ANSI_GREEN}Log upload complete!{ANSI_ESCAPE}")
+        return
 
     while True:
         message: bytes
+
 
         if args.randomList:
             try:

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -547,7 +547,7 @@ def main():
     source_group.add_argument("--live-on", nargs='+',
                               help=("Args create a list of message classes or ID's to stream to grafana. no args for all, all for all"))
     
-    source_group.add_argument("-u", "--log-upload", action="store_true",
+    source_group.add_argument("-u", "--log-upload", nargs='+',
                             help=("Will attempt to upload each line of each file in the logfiles directory "
                                 "If upload does not succeed then these lines will be stored "
                                 "in a file named `FAILED_UPLOADS.txt in the logfiles directory`"))
@@ -562,9 +562,6 @@ def main():
     source_group.add_argument("--dbc", action="store",
                               help="Specifies the dbc file to use. For example: ./dbc/brightside.dbc"
                               "Default: ./dbc/brightside.dbc")
-    
-    source_group.add_argument("--fast-u", action="store_true",
-                            help=("Same as -u but will only do 1 of the 15 Log containers"))
 
     source_group.add_argument("-f", "--frequency-hz", action="store", default=DEFAULT_RANDOM_FREQUENCY_HZ, type=int,
                               help=((f"Specifies the frequency (in Hz) for random message generation. \

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -707,7 +707,6 @@ def main():
     
     if args.log_upload:
         upload_logs(args, live_filters, log_filters, display_filters, LOG_WRITE_ENDPOINT)
-        print(f"{ANSI_GREEN}Log upload complete!{ANSI_ESCAPE}")
         return
 
     while True:

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -20,6 +20,9 @@ PATTERN_DATETIME    = re.compile(r't:\s+(.*?)\s+DateTime:\s+(.*)')
 PATTERN_TRIGGER     = re.compile(r't:\s+(.*?)\s+Log Trigger Event.*')
 PATTERN_EVENT       = re.compile(r't:\s+(.*?)\s+ch:0 f:\s+(.*?) id:(.*?) dlc:\s+(.*?) d:(.*)')
 
+# Data Constants
+ERROR_ID            = 0
+
 
 def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
     start_time = None
@@ -40,7 +43,7 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
 
             id = int(match.group(3).strip(), 16)
 
-            if id == 0:
+            if id == ERROR_ID:
                 continue
             
             id_str = id.to_bytes(4, 'big').decode('latin-1') 

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -7,7 +7,7 @@ import struct
 LOG_FOLDER          = "/media/aarjav/disk/"
 NUM_LOGS            = 15
 MB_TO_KB            = 1024
-EPOCH_START         = datetime.datetime(1970, 1, 1)
+EPOCH_START         = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
 # Formatting Constants
 ANSI_GREEN          = "\033[92m"

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -18,7 +18,7 @@ ANSI_RESET          = "\033[0m"
 # Regex Patterns for logfile parsing
 PATTERN_DATETIME    = re.compile(r't:\s+(.*?)\s+DateTime:\s+(.*)')
 PATTERN_TRIGGER     = re.compile(r't:\s+(.*?)\s+Log Trigger Event.*')
-PATTERN_EVENT       = re.compile(r't:\s+(.*?)\s+ch:0 f:\s+(.*?) id:\s+(.*?) dlc:\s+(.*?) d:(.*)')
+PATTERN_EVENT       = re.compile(r't:\s+(.*?)\s+ch:0 f:\s+(.*?) id:(.*?) dlc:\s+(.*?) d:(.*)')
 
 
 def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
@@ -38,7 +38,7 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
             timestamp = start_time + float(match.group(1))
             timestamp_str = struct.pack('>d', timestamp).decode('latin-1')
 
-            id = int(match.group(3), 16)
+            id = int(match.group(3).strip(), 16)
 
             if id == 0:
                 continue
@@ -56,8 +56,10 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
             
 
 def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
+    numLogs = 1 if args.fast_u else NUM_LOGS
+
     # Open each KMF file
-    for i in range(NUM_LOGS):
+    for i in range(numLogs):
         log_path = LOG_FOLDER + "LOG000{:02d}.KMF".format(i)
         kmf_file = kvmlib.openKmf(log_path.format(i))
         print(f"{ANSI_GREEN}Opening file: {log_path.format(i)}{ANSI_RESET}")  # Green stdout
@@ -94,7 +96,7 @@ def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_f
 
     upload_input = input(f"{ANSI_GREEN}Do you want to upload all logs now (y/n)?: {ANSI_RESET} ")
     if upload_input.lower() == 'y' or upload_input.lower() == '\n':
-        for i in range(NUM_LOGS):
+        for i in range(numLogs):
             log_path = LOG_FOLDER + "LOG000{:02d}".format(i)
             kmf_file = kvmlib.openKmf(log_path.format(i))
             print(f"{ANSI_GREEN}Opening file: {log_path.format(i)}{ANSI_RESET}")  # Green stdout

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -4,7 +4,7 @@ import datetime
 import struct
 
 # Script Constants
-LOG_FOLDER          = "/media/eletrical/disk/"
+LOG_FOLDER          = "/media/electrical/disk/"
 NUM_LOGS            = 15
 MB_TO_KB            = 1024
 EPOCH_START         = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -39,6 +39,10 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
             timestamp_str = struct.pack('>d', timestamp).decode('latin-1')
 
             id = int(match.group(3), 16)
+
+            if id == 0:
+                continue
+            
             id_str = id.to_bytes(4, 'big').decode('latin-1') 
 
             dlc_str = match.group(4)
@@ -103,7 +107,9 @@ def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_f
                 upload(log[j], parserCallFunc, live_filters, log_filters, display_filters, args, endpoint)
 
             # Clear the log files
-            log.delete_all()
+            delete_input = input(f"{ANSI_GREEN}Do you want to {ANSI_RESET}{ANSI_RED}DELETE{ANSI_RESET} {ANSI_GREEN}all logs now (y/n)?: {ANSI_RESET} ")
+            if delete_input.lower() == 'y' or delete_input.lower() == '\n':
+                log.delete_all()
             
             # Close the KMF file
             kmf_file.close()

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -4,7 +4,7 @@ import datetime
 import struct
 
 # Script Constants
-LOG_FOLDER          = "/media/aarjav/disk/"
+LOG_FOLDER          = "/media/eletrical/disk/"
 NUM_LOGS            = 15
 MB_TO_KB            = 1024
 EPOCH_START         = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -4,10 +4,10 @@ import datetime
 import struct
 
 # Script Constants
-LOG_FOLDER          = "/media/electrical/disk/"
+LOG_FOLDER          = "/media/aarjav/disk/"
 NUM_LOGS            = 15
 MB_TO_KB            = 1024
-EPOCH_START         = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+EPOCH_START         = datetime.datetime(1970, 1, 1)
 
 # Formatting Constants
 ANSI_GREEN          = "\033[92m"
@@ -31,9 +31,9 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
         if PATTERN_DATETIME.search(str_event):
             match = PATTERN_DATETIME.search(str_event)
             date_time_str = match.group(2)
-            date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S')
-            date_time_obj = date_time_obj.replace(tzinfo=datetime.timezone.utc)  
-            start_time = (date_time_obj - EPOCH_START).total_seconds()
+            date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S') 
+            utc_date_time_obj = date_time_obj.astimezone(datetime.timezone.utc)                 # Convert to UTC
+            start_time = (utc_date_time_obj - EPOCH_START).total_seconds()
         elif PATTERN_TRIGGER.search(str_event):
             continue
         elif PATTERN_EVENT.search(str_event):
@@ -97,7 +97,7 @@ def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_f
         # Close the KMF file
         kmf_file.close()
 
-    upload_input = input(f"{ANSI_GREEN}Do you want to upload all logs now (y/n)?: {ANSI_RESET} ")
+    upload_input = input(f"{ANSI_GREEN}Do you want to upload all logs now (y/n)?: {ANSI_RESET} \n")
     if upload_input.lower() == 'y' or upload_input.lower() == '\n':
         for i in range(numLogs):
             log_path = LOG_FOLDER + "LOG000{:02d}".format(i)

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -56,7 +56,7 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
             
 
 def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
-    numLogs = 1 if args.fast_u else NUM_LOGS
+    numLogs = 1 if "fast" in [option.lower() for option in args.log_upload] else NUM_LOGS
 
     # Open each KMF file
     for i in range(numLogs):


### PR DESCRIPTION
**Changes**:
* Extended IDs in the .KMF file had **no spacing** between the `id:` field. So `id:<ID>` vs `id: <ID>` would mean that the extended ID's without a space would **miss the regex and thus would not upload**. Regex is fixed for this
* Fast upload option by doing `-u fast`. Also `-u all` still exists. `README.md` updated to reflect this change
* Note: the log upload data goes to the `_log` suffixed bucket. 

**Testing**:
* Deleted and recreated CAN_log bucket on elec computer. Did `./link_telemetry -u fast` and confirmed messages showed on influxDB. Deleted CAN_log bucket again and recreated it. Did `./link_telemetry -u all` this time and again confirmed messages showed on InfluxDB.
* Battery Current Message Example:
![image](https://github.com/UBC-Solar/sunlink/assets/117491745/8fa36be0-b307-4535-8b8b-1a36550f60de)


**Pre-merge Steps:**
* ~Use tomorrow's testing day to confirm functionality. Since we will use someone's laptop as Sunlink the elec computer will not have the data we collected during testing. Thus, this will be a good way to see if the memorator upload script is working.~**WORKS AND UPLOADED TO SERVER**