### PR TITLE
Feat: Sunlink Uptime Tracker (runtime counter + msg processed count + curr time)

### DIFF
--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -502,7 +502,7 @@ def displaySunlinkTracking():
         current_formatted_time = current_datetime.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
         # 1ms precisios
         sunlink_formatted_runtime = str(sunlink_runtime)[:-3]
-        msg = f"Proccessed {num_processed_msgs} messages in {sunlink_formatted_runtime}. Current Time: {current_formatted_time}"
+        msg = f"LINK_TELEMETRY: Proccessed {num_processed_msgs} Messages in {sunlink_formatted_runtime}. Current Time: {current_formatted_time}"
 
         sys.stdout.write(parameters.ANSI_SAVE_CURSOR)  # Save cursor position
         sys.stdout.write(f"{parameters.ANSI_YELLOW}{msg}{ANSI_ESCAPE}")  # Yellow text

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -45,3 +45,9 @@ ANSI_RED = "\033[1;31m"
 ANSI_GREEN = "\033[1;32m"
 ANSI_YELLOW = "\033[1;33m"
 ANSI_BOLD = "\033[1m"
+ANSI_SAVE_CURSOR = "\0337"
+ANSI_RESTORE_CURSOR = "\0338"
+
+
+# Sunlink Tracking Display Rate
+DISPLAY_RATE            = 0.005


### PR DESCRIPTION
## Sunlink Uptime Tracker
* **Problem**: When using no table on or logging arguments it can be hard to tell if sunlink is even running because no outputs are seen on the terminal (assuming no parse fails). This is why the sunlink tracker was implemented.
* **Feature**: Added a runtime counter that sits at the bottom of the screen and will display the current time, sunlink runtime and number of callbacks received (whether successful or not).
* **Notes**: The `-t` for track (or time if you want to remember it that way) can be used to FORCE the uptime message to be displayed. However, the uptime message is always displayed when table and logging is off. If you turn on tables or logging you **need to add** the `-t` option to indicate that you still want to see the uptime.
* **Example Output:**
![image](https://github.com/UBC-Solar/sunlink/assets/117491745/3fe4ca31-734d-4ba7-9ac1-c334a042fd0a)
* **Example Commands**:
     * No tables, no logging, yes sunlink uptime msg: `./link_telemetry.py -r can --debug`
     * No tables, no logging, yes sunlink uptime msg: `./link_telemetry.py -r can --debug -t`
     * Yes tables, no logging, yes sunlink uptime msg: `./link_telemetry.py -r can --debug --table-on all -t`
     * Yes tables, no logging, no sunlink uptime msg: `./link_telemetry.py -r can --debug --table-on all`
     * Yes tables, yes logging, yes sunlink uptime msg: `./link_telemetry.py -r can --debug --table-on all --log all -t`
* **Note(s)**: If displaying this message takes up too much CPU power then you go to `parameters.py` inside the `parser/` folder and change the `DISPLAY_RATE` constant to something else. Currently it refreshes at 5ms. 

## Monday Link
[Electrical TODO Medium Priority](https://ubcsolar.monday.com/docs/6887599919)

## Effected Components
<!-- Check which components are affected -->
- [x] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [x] Randomizer testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
I ran all the commands in the example commands list + some other combinations and confirmed it worked correctly.
**I NEED TO DO LOG UPLOAD WITH ELEC COMPUTER AND MEMORATOR SD CARD FOR FINAL CONFIRMATION**

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [x] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
