### PR TITLE
Feat: Splitting Large Log Files

### DIFF
--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -321,8 +321,6 @@ def write_to_log_file(message: str, log_file_name: str, type: str, convert_to_he
         _doWrite(message, log_file_name, int(num_fail_chars / parameters.MAX_FILE_CHARS), convert_to_hex)
     elif type == "log":
         num_log_chars += len(str(message))
-        # print(f"num_log_chars: {num_log_chars}")
-        print(f"num_log_chars / parameters.MAX_FILE_CHARS: {int(num_log_chars / parameters.MAX_FILE_CHARS)}")
         _doWrite(message, log_file_name, int(num_log_chars / parameters.MAX_FILE_CHARS), convert_to_hex)
     elif type == "dbg":
         num_dbg_chars += len(str(message))

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -26,7 +26,7 @@ import warnings
 import threading
 
 import concurrent.futures
-# from tools.MemoratorUploader import memorator_upload_script
+from tools.MemoratorUploader import memorator_upload_script
 
 
 __PROGRAM__ = "link_telemetry"

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -350,8 +350,8 @@ def process_response(future: concurrent.futures.Future, args, display_filters: l
     formatted_time = current_log_time.strftime('%Y-%m-%d_%H:%M:%S')
 
     global num_processed_msgs
-    num_processed_msgs += 1     
-
+    num_processed_msgs += 1                             # A call back is received so our request was processed
+    
     # get the response from the future
     response = future.result()
 

--- a/link_telemetry.py
+++ b/link_telemetry.py
@@ -26,7 +26,7 @@ import warnings
 import threading
 
 import concurrent.futures
-from tools.MemoratorUploader import memorator_upload_script
+# from tools.MemoratorUploader import memorator_upload_script
 
 
 __PROGRAM__ = "link_telemetry"
@@ -306,14 +306,39 @@ def parser_request(payload: Dict, url: str):
     else:
         return r
 
-def write_to_log_file(message: str, log_file_name, convert_to_hex=True):
+
+# If the number of lines is more than 1000000 then write to new file
+num_fail_chars = 0
+num_log_chars = 0
+num_dbg_chars = 0
+def write_to_log_file(message: str, log_file_name: str, type: str, convert_to_hex=True):
+    global num_fail_chars
+    global num_log_chars 
+    global num_dbg_chars
+
+    if type == "fail":
+        num_fail_chars += len(str(message))
+        _doWrite(message, log_file_name, int(num_fail_chars / parameters.MAX_FILE_CHARS), convert_to_hex)
+    elif type == "log":
+        num_log_chars += len(str(message))
+        # print(f"num_log_chars: {num_log_chars}")
+        print(f"num_log_chars / parameters.MAX_FILE_CHARS: {int(num_log_chars / parameters.MAX_FILE_CHARS)}")
+        _doWrite(message, log_file_name, int(num_log_chars / parameters.MAX_FILE_CHARS), convert_to_hex)
+    elif type == "dbg":
+        num_dbg_chars += len(str(message))
+        _doWrite(message, log_file_name, int(num_dbg_chars / parameters.MAX_FILE_CHARS), convert_to_hex)
+
+
+def _doWrite(message: str, log_file_name: str, suffix: str, convert_to_hex=True):
     # Message encoded to hex to ensure all characters stay
-        if convert_to_hex:
-            with open(log_file_name, "a", encoding='latin-1') as output_log_file:
-                output_log_file.write(message.encode('latin-1').hex() + '\n')
-        else:
-            with open(log_file_name, "a") as output_log_file:
-                print(message, file=output_log_file)
+    new_file_name = f"{log_file_name}_{suffix}"
+    if convert_to_hex:
+        with open(new_file_name, "a", encoding='latin-1') as output_log_file:
+            output_log_file.write(message.encode('latin-1').hex() + '\n')
+    else:
+        with open(new_file_name, "a") as output_log_file:
+            print(message, file=output_log_file)
+
 
 
 def process_response(future: concurrent.futures.Future, args, display_filters: list):
@@ -327,7 +352,7 @@ def process_response(future: concurrent.futures.Future, args, display_filters: l
     formatted_time = current_log_time.strftime('%Y-%m-%d_%H:%M:%S')
 
     global num_processed_msgs
-    num_processed_msgs += 1                             # A call back is received so our request was processed
+    num_processed_msgs += 1     
 
     # get the response from the future
     response = future.result()
@@ -359,8 +384,6 @@ def process_response(future: concurrent.futures.Future, args, display_filters: l
     all_responeses = parse_response['all_responses']
     for response in all_responeses:
         if response["result"] == "OK":
-
-
             table = None
             do_display_table = filter_stream(response, display_filters)
             if args.log is not None or do_display_table:
@@ -397,23 +420,23 @@ def process_response(future: concurrent.futures.Future, args, display_filters: l
                 print(table)
 
             if response["logMessage"]:
-                write_to_log_file(table, LOG_FILE_NAME, convert_to_hex=False)
+                write_to_log_file(table, LOG_FILE_NAME, "log", convert_to_hex=False)
             
         elif response["result"] == "PARSE_FAIL":
             fail_msg = f"{ANSI_RED}PARSE_FAIL{ANSI_ESCAPE}: \n" + f"{response['error']}"
             print(fail_msg)
 
             # If log upload AND parse fails then log again to the FAILED_UPLOADS.txt file. If no log upload do normal
-            write_to_log_file(response['message'], os.path.join(FAIL_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else FAIL_FILE_NAME)
-            write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
+            write_to_log_file(response['message'], os.path.join(FAIL_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else FAIL_FILE_NAME, "fail")
+            write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, "dbg", convert_to_hex=False)
         elif response["result"] == "INFLUX_WRITE_FAIL":
             fail_msg = f"{ANSI_RED}INFLUX_WRITE_FAIL{ANSI_ESCAPE}: \n" + f"{response['error']}"
             print(f"Failed to write measurements for {response['type']} message to InfluxDB!")
             print(response)
 
             # If log upload AND INFLUX_WRITE_FAIL fails then log again to the FAILED_UPLOADS.txt file. If no log upload do normal
-            write_to_log_file(response['message'], os.path.join(FAIL_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else FAIL_FILE_NAME)
-            write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, convert_to_hex=False)
+            write_to_log_file(response['message'], os.path.join(FAIL_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else FAIL_FILE_NAME, "fail")
+            write_to_log_file(fail_msg + '\n', os.path.join(DEBUG_DIRECTORY, "FAILED_UPLOADS_{}.txt".format(formatted_time)) if args.log_upload else DEBUG_FILE_NAME, "dbg", convert_to_hex=False)
         else:
             print(f"Unexpected response: {response['result']}")
 

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -49,5 +49,9 @@ ANSI_SAVE_CURSOR = "\0337"
 ANSI_RESTORE_CURSOR = "\0338"
 
 
+# Log File Constants
+MAX_FILE_CHARS = 100000000
+
 # Sunlink Tracking Display Rate
 DISPLAY_RATE            = 0.005
+

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -52,7 +52,8 @@ ANSI_RESTORE_CURSOR = "\0338"
 # Log File Constants. 110,000,000 characters is around when the file crashes (with some leeway)
 # However, when running the code with 100,000,00 set as the parameter we check the log file and it consistenly has 1.5 times the characters
 # Thus, we will stop logging at 100,000,000 / 1.5 characters so that the logfile will end up with around 110,000,000 characters and not crash
-MAX_FILE_CHARS          = 73333333
+# Then because of a range of computer capabiities we will set the max file size to be half this: 55,000,000 characters.
+MAX_FILE_CHARS          = 36666666
 
 # Sunlink Tracking Display Rate
 DISPLAY_RATE            = 0.005

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -49,7 +49,9 @@ ANSI_SAVE_CURSOR = "\0337"
 ANSI_RESTORE_CURSOR = "\0338"
 
 
-# Log File Constants
+# Log File Constants. 110,000,000 characters is around when the file crashes (with some leeway)
+# However, when running the code with 100,000,00 set as the parameter we check the log file and it consistenly has 1.5 times the characters
+# Thus, we will stop logging at 100,000,000 / 1.5 characters so that the logfile will end up with around 110,000,000 characters and not crash
 MAX_FILE_CHARS          = 73333333
 
 # Sunlink Tracking Display Rate

--- a/parser/parameters.py
+++ b/parser/parameters.py
@@ -50,7 +50,7 @@ ANSI_RESTORE_CURSOR = "\0338"
 
 
 # Log File Constants
-MAX_FILE_CHARS = 100000000
+MAX_FILE_CHARS          = 73333333
 
 # Sunlink Tracking Display Rate
 DISPLAY_RATE            = 0.005


### PR DESCRIPTION
## Splitting Large Log Files
In testing if we use the --log option sometimes log files can reach millions of lines and hundreds of millions of characters. Sometimes the files are so big that you cant even open them (application crashes). This feature will now create a new log file (same name as before but with a suffix indicating the index like 0, 1, 2, 3)

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [x] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [x] Vehicle testing
- [x] Randomizer testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [x] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
