### PR TITLE
fix: added 6ms delay between memorator upload messages

### DIFF
--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -2,26 +2,30 @@ import canlib.kvmlib as kvmlib
 import re
 import datetime
 import struct
+import time
 
 # Script Constants
-LOG_FOLDER          = "/media/electrical/disk/"
-NUM_LOGS            = 15
-MB_TO_KB            = 1024
-EPOCH_START         = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+LOG_FOLDER              = "/media/electrical/disk/"
+NUM_LOGS                = 15
+MB_TO_KB                = 1024
+EPOCH_START             = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 
 # Formatting Constants
-ANSI_GREEN          = "\033[92m"
-ANSI_BOLD           = "\033[1m"
-ANSI_RED            = "\033[91m"
-ANSI_RESET          = "\033[0m"
+ANSI_GREEN              = "\033[92m"
+ANSI_BOLD               = "\033[1m"
+ANSI_RED                = "\033[91m"
+ANSI_RESET              = "\033[0m"
 
 # Regex Patterns for logfile parsing
-PATTERN_DATETIME    = re.compile(r't:\s+(.*?)\s+DateTime:\s+(.*)')
-PATTERN_TRIGGER     = re.compile(r't:\s+(.*?)\s+Log Trigger Event.*')
-PATTERN_EVENT       = re.compile(r't:\s+(.*?)\s+ch:0 f:\s+(.*?) id:(.*?) dlc:\s+(.*?) d:(.*)')
+PATTERN_DATETIME        = re.compile(r't:\s+(.*?)\s+DateTime:\s+(.*)')
+PATTERN_TRIGGER         = re.compile(r't:\s+(.*?)\s+Log Trigger Event.*')
+PATTERN_EVENT           = re.compile(r't:\s+(.*?)\s+ch:0 f:\s+(.*?) id:(.*?) dlc:\s+(.*?) d:(.*)')
 
 # Data Constants
-ERROR_ID            = 0
+ERROR_ID                = 0
+
+# Delay Constants
+SEND_TO_PARSER_DELAY    = 0.006
 
 
 def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
@@ -56,6 +60,7 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
             can_str = timestamp_str + "#" + id_str + data_str + dlc_str
 
             parserCallFunc(can_str, live_filters, log_filters, display_filters, args, endpoint)
+            time.sleep(SEND_TO_PARSER_DELAY)
             
 
 def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
* Noticed yesterday during memorator upload that the computers RAM was rapidly being used by the memorator upload script due to all the http requests and callbacks. Although this never happened before when we performed the memorator upload script decided it was safe to add a 6ms delay between every uploaded message (tested with 10ms and confirmed that RAM never indefinetly increased). Would need to test with 6ms and possibly lower this number as much as possible.

* After testing on the bay computer and changing the delay all they way down to 1ms I noticed still no increase in RAM used by the program. Although this is a good sign to reduce the delay the test is not completely valid because the number of CAN messages on memorator is significantly reduced so the number of messages that can accumulate in RAM is limited (with no delay added I saw RAM climb to only 3.5% but in the 4.8 million message test the RAM increased to 70% and crashed mediately). 

* Because of the incompleteness of this test and also to accommodate for larger loads I have kept the delay at 6ms. This will benefit a larger range or computers by sufficiently delaying request times so less memory is used.

* **Note:** If we notice that the memorator upload script is taking a significantly long time and it is necessary to speed it up we can remove this delay as long as the computer does not crash mid way through.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [x] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
Will use memorator upload script and check RAM usage using the top command.

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
