### PR TITLE
Feat: added Tailscale setup doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,9 @@ Here are some example invocations:
 
 The offline log uploader will use the `MemoratorUploader` script in the `tools/` folder to read the contents of the SD card on the Memorator and then upload those messages to InfluxDB. There are two options for this: `-u fast` and `-u all`. `-u fast` will only upload one Log File Container (1 .KMF file will be read). In `-u all` all 15 .KMF files on the SD card will be read and their data will be uploaded. Note: data is sent to the `_log` suffixed bucket.
 
+> [!IMPORTANT]
+> It is highly recommended to run this script in a separate terminal (not using a terminal in VSCode). From experience the program is prone to crashing when running the upload script in a VSCode terminal.
+
 ```bash
 ./link_telemetry.py -u fast
 ./link_telemetry.py -u all

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A detailed description of all system components is given [here](/docs/SYSTEM.md)
 
 When attempting to set up Sunlink, it is important to decide whether you want to set up both the telemetry cluster and telemetry link or just the telemetry link.
 
+-   If you only want to view our data on InfluxDB or Grafana then you will need to be added to our Tailscale network. [Click here for the instructions to do so](docs/TAILSCALE_SETUP.md).
 -   If the telemetry cluster has **already been set up** and you would like to only set up the telemetry link to communicate with the cluster, skip to [this section](#telemetry-link-setup).
 
 -   If the telemetry cluster has **not been set up**, continue onwards to set it up.

--- a/docs/TAILSCALE_SETUP.md
+++ b/docs/TAILSCALE_SETUP.md
@@ -6,20 +6,15 @@ During driving sessions we collect millions of CAN messages on the Kvaser Memora
 2. Click **Download Tailscale for Windows**
 3. Once downloaded run the .exe file
 4. Agree to the terms and conditions and click **Install**
-5. Now we need to sign into tailscale with GitHub using the solar admin account **(make sure to sign out afterwards**). To do this go to [Tailscale's sign in page](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://login.tailscale.com/start&ved=2ahUKEwiZteTtw5WHAxVgiY4IHYhoAFIQFnoECCEQAQ&usg=AOvVaw1buC-MDlbw2TpOpK4NqiP9)
-6. Click **Sign up with GitHub**
-7. **Ask Team Lead for Solar Admin Credentials**
-8. Once you sign in it will ask for a verification code sent to the `admin@ubcsolar.com` email. Again, **ask Team lead for this verification code.**
-9. Enter the code and click **Authorize Tailscale**
-10. Then click on **ubcsolar-admin.github**
-11. Once you are authorized we need to actually connect your device to the Tailscale network. 
-12. Since we are on windows, open **Powershell** as an administrator.
-13. Then run `tailscale up`. This will redirect you to a web browser on which it will ask you to select a tailnet. Here, click **ubcsolar-admin.github** and then click **Connect**
-14. Then you will need to login to tailscale so like before choose **Sign in with GitHub**
-15. Then click **Authorize Tailscale**. Note here you may be asked to select a tailscale network to connect to again so simply select **ubcsolar-admin.github** and then click **Connect**. **Note: pay attention to your device name as it comes up on this screen so you can identify it in the machines tab on tailscale**.
-16. Now, on the **Machines** tab of tailscale you should see your device listed. It is recommended to click the 3 dots on the line with your machine name and then select **Edit machine name**. Here unselect **Auto-generate from OS hostname** and enter something suitable and unique. Then click **Update Name**.
-17. Now you should be able to access services like `influxdb.telemetry.ubcsolar.com` and `grafana.telemetry.ubcsolar.com`. Make sure to sign in with `admin` and `new_password`.
-18. Go back to GitHub and sign out of the solar admin account.'
+5. Once Tailscale is installed open **Powershell** as an administrator.
+6. Run the command `tailscale up --auth-key <ASK_LEAD_FOR_AUTHKEY>`
+7. Now you should be able to access services like `influxdb.telemetry.ubcsolar.com` and `grafana.telemetry.ubcsolar.com`. Make sure to sign in with `admin` and `new_password`.
 
 ## Linux (Ubuntu)
-Coming soon...
+1. Navigate to [Tailscale's website to download it for windows](https://tailscale.com/download/linux) to see these same commands under the manual set up instructions.
+2. Run `curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null`
+3. Then run `curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list`
+4. Then run `sudo apt-get update`
+5. Then run `sudo apt-get install tailscale`
+6. Then run `sudo tailscale up --auth-key <ASK_LEAD_FOR_AUTH_KEY>`
+7. Now you should be able to access services like `influxdb.telemetry.ubcsolar.com` and `grafana.telemetry.ubcsolar.com`. Make sure to sign in with `admin` and `new_password`.

--- a/docs/TAILSCALE_SETUP.md
+++ b/docs/TAILSCALE_SETUP.md
@@ -1,0 +1,25 @@
+# How to Setup Tailscale to Access Production Data
+During driving sessions we collect millions of CAN messages on the Kvaser Memorator. To view this data we then take the SD card on the Memorator and use the `MemoratorUploader.py` script to upload the data to InfluxDB. However, this data can only be viewed on the computer which it is uploaded on. The problem here is that other teams like **Race Strategy** need to access this data somehow to analyze it and provide an optimal race strategy. To combat this problem we have set up a Tailscale network with Cloudflare tunnelling on the Bay computer which enables other members of the Tailscale network to access this data on `influxdb.telemetry.ubcsolar.com`. Below are the steps to get onto the Tailscale network.
+
+## Windows
+1. Navigate to [Tailscale's website to download it for windows](https://tailscale.com/download/windows)
+2. Click **Download Tailscale for Windows**
+3. Once downloaded run the .exe file
+4. Agree to the terms and conditions and click **Install**
+5. Now we need to sign into tailscale with GitHub using the solar admin account **(make sure to sign out afterwards**). To do this go to [Tailscale's sign in page](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://login.tailscale.com/start&ved=2ahUKEwiZteTtw5WHAxVgiY4IHYhoAFIQFnoECCEQAQ&usg=AOvVaw1buC-MDlbw2TpOpK4NqiP9)
+6. Click **Sign up with GitHub**
+7. **Ask Team Lead for Solar Admin Credentials**
+8. Once you sign in it will ask for a verification code sent to the `admin@ubcsolar.com` email. Again, **ask Team lead for this verification code.**
+9. Enter the code and click **Authorize Tailscale**
+10. Then click on **ubcsolar-admin.github**
+11. Once you are authorized we need to actually connect your device to the Tailscale network. 
+12. Since we are on windows, open **Powershell** as an administrator.
+13. Then run `tailscale up`. This will redirect you to a web browser on which it will ask you to select a tailnet. Here, click **ubcsolar-admin.github** and then click **Connect**
+14. Then you will need to login to tailscale so like before choose **Sign in with GitHub**
+15. Then click **Authorize Tailscale**. Note here you may be asked to select a tailscale network to connect to again so simply select **ubcsolar-admin.github** and then click **Connect**. **Note: pay attention to your device name as it comes up on this screen so you can identify it in the machines tab on tailscale**.
+16. Now, on the **Machines** tab of tailscale you should see your device listed. It is recommended to click the 3 dots on the line with your machine name and then select **Edit machine name**. Here unselect **Auto-generate from OS hostname** and enter something suitable and unique. Then click **Update Name**.
+17. Now you should be able to access services like `influxdb.telemetry.ubcsolar.com` and `grafana.telemetry.ubcsolar.com`. Make sure to sign in with `admin` and `new_password`.
+18. Go back to GitHub and sign out of the solar admin account.'
+
+## Linux (Ubuntu)
+Coming soon...

--- a/docs/TAILSCALE_SETUP.md
+++ b/docs/TAILSCALE_SETUP.md
@@ -2,7 +2,7 @@
 During driving sessions we collect millions of CAN messages on the Kvaser Memorator. To view this data we then take the SD card on the Memorator and use the `MemoratorUploader.py` script to upload the data to InfluxDB. However, this data can only be viewed on the computer which it is uploaded on. The problem here is that other teams like **Race Strategy** need to access this data somehow to analyze it and provide an optimal race strategy. To combat this problem we have set up a Tailscale network with Cloudflare tunnelling on the Bay computer which enables other members of the Tailscale network to access this data on `influxdb.telemetry.ubcsolar.com`. Below are the steps to get onto the Tailscale network.
 
 ## Windows
-1. Navigate to [Tailscale's website to download it for windows](https://tailscale.com/download/windows)
+1. Navigate to [Tailscale's website to download it for **Windows**](https://tailscale.com/download/windows)
 2. Click **Download Tailscale for Windows**
 3. Once downloaded run the .exe file
 4. Agree to the terms and conditions and click **Install**
@@ -11,7 +11,7 @@ During driving sessions we collect millions of CAN messages on the Kvaser Memora
 7. Now you should be able to access services like `influxdb.telemetry.ubcsolar.com` and `grafana.telemetry.ubcsolar.com`. Make sure to sign in with `admin` and `new_password`.
 
 ## Linux (Ubuntu)
-1. Navigate to [Tailscale's website to download it for windows](https://tailscale.com/download/linux) to see these same commands under the manual set up instructions.
+1. Navigate to [Tailscale's website to download it for **Linux**](https://tailscale.com/download/linux) to see these same commands under the manual set up instructions.
 2. Run `curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null`
 3. Then run `curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/jammy.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list`
 4. Then run `sudo apt-get update`

--- a/setup.sh
+++ b/setup.sh
@@ -296,12 +296,12 @@ sudo docker compose down
 sudo docker compose up -d
 
 # Setting up Tailscale
-echo -ne "${ANSI_BOLD}Would you like to Set Up Tailscale (y/n)?: $ANSI_RESET"
+echo -ne "${ANSI_YELLOW}Would you like to Set Up Tailscale (y/n)?: $ANSI_RESET"
 read setupTailscale
-echo -ne "${ANSI_BOLD}ENTER your Tailscale authkey here (you may need to ask your lead for this): $ANSI_RESET"
+echo -ne "${ANSI_YELLOW}ENTER your Tailscale authkey here (you may need to ask your lead for this): $ANSI_RESET"
 read tailscaleAuthKey
 if [ $setupTailscale = "y" ]; then
-    echo -e "${ANSI_YELLOW}Setting up Tailscale... $ANSI_RESET"
+    echo -e "${ANSI_BOLD}Setting up Tailscale... $ANSI_RESET"
     sudo apt-get install -y curl
     curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
     curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
@@ -310,7 +310,7 @@ if [ $setupTailscale = "y" ]; then
     sudo tailscale up --auth-key $tailscaleAuthKey
     echo -e "${ANSI_GREEN}DONE setting up Tailscale! $ANSI_RESET"
 else
-    echo -e "${ANSI_YELLOW}Skipping Tailscale setup... $ANSI_RESET"
+    echo -e "${ANSI_BOLD}Skipping Tailscale setup... $ANSI_RESET"
 fi
 
 echo -e "\n\n"

--- a/setup.sh
+++ b/setup.sh
@@ -295,6 +295,23 @@ echo -e "${ANSI_YELLOW}Restarting docker containers one last time... $ANSI_RESET
 sudo docker compose down
 sudo docker compose up -d
 
+# Setting up Tailscale
+echo -ne "${ANSI_BOLD}Would you like to Set Up Tailscale (y/n)?: $ANSI_RESET"
+read setupTailscale
+echo -ne "${ANSI_BOLD}ENTER your Tailscale authkey here (you may need to ask your lead for this): $ANSI_RESET"
+read tailscaleAuthKey
+if [ $setupTailscale = "y" ]; then
+    echo -e "${ANSI_YELLOW}Setting up Tailscale... $ANSI_RESET"
+    sudo apt-get install -y curl
+    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+    sudo apt-get update
+    sudo apt-get install tailscale
+    sudo tailscale up --auth-key $tailscaleAuthKey
+    echo -e "${ANSI_GREEN}DONE setting up Tailscale! $ANSI_RESET"
+else
+    echo -e "${ANSI_YELLOW}Skipping Tailscale setup... $ANSI_RESET"
+fi
 
 echo -e "\n\n"
 echo -e "${ANSI_YELLOW}<---ALMOST COMPLETED SETTING UP SUNLINK. YOU NEED TO RUN THE FOLLOWING (Ctrl+Shift+C to copy) --->$ANSI_RESET"


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
Provides instructions for setting up tailscale on Windows and Linux and also made the setup script perform the Linux Setup. an Authkey is required by the user so as to not leak our authkey...

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [x] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [x] Other
- [ ] N/A

<!-- Describe your testing steps here -->
I followed these exact instructions on my microsoft surface and started from not being able to access influxdb.telemetry.ubcsolar.com to then being able to access it and viewing all the latest data.

I followed Linux instructions on WSL and it worked.

I deleted sunlink and uninstalled tailscale and then reinstalled sunlink and entered yes to the prompt asking to setup tailscale and confirmed I can access influxdb.telemetry.ubcsolar.com

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [x] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
