### PR TITLE
Fix: PyYAML 6.0 not supported in Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-can==4.0.0
 python-dateutil==2.8.2
 python-dotenv==0.20.0
 pytz==2022.1
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 Rx==3.2.0
 six==1.16.0


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
 PyYAML 6.0 not supported in Python 3.12 so if you have this Python version and ran the setup script it would fail throwing this error:
![image](https://github.com/user-attachments/assets/baf53cde-e10a-41fd-9b82-5893b620507a)

[Also this GitHub Issue address this problem](https://github.com/yaml/pyyaml/issues/756).

As such we changed the requirements.txt to use PyYAML==6.0.1

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [x] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
I ran the setup script on my Python 3.10.12 and it works. I dont see it not working for another version online.

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
