### PR TITLE
Fix: added path as input to memorator uploader script

### DIFF
--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -136,4 +136,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -5,7 +5,8 @@ import struct
 import time
 
 # Script Constants
-LOG_FOLDER              = "/media/electrical/disk/"
+global LOG_FOLDER
+# LOG_FOLDER              = "/media/electrical/disk/"
 NUM_LOGS                = 15
 MB_TO_KB                = 1024
 EPOCH_START             = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
@@ -65,6 +66,9 @@ def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: lis
 
 def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
     numLogs = 1 if "fast" in [option.lower() for option in args.log_upload] else NUM_LOGS
+    
+    # Get the log folder path as input
+    LOG_FOLDER = input(f"{ANSI_GREEN}Enter the FULL ABSOLUTE path to the log folder contianing .KMF files: {ANSI_RESET} ")  
 
     # Open each KMF file
     for i in range(numLogs):

--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -68,7 +68,7 @@ def memorator_upload_script(parserCallFunc: callable, live_filters: list,  log_f
     numLogs = 1 if "fast" in [option.lower() for option in args.log_upload] else NUM_LOGS
     
     # Get the log folder path as input
-    LOG_FOLDER = input(f"{ANSI_GREEN}Enter the FULL ABSOLUTE path to the log folder contianing .KMF files: {ANSI_RESET} ")  
+    LOG_FOLDER = input(f"{ANSI_GREEN}Enter the FULL ABSOLUTE path to the folder with .KMF files (include '/' at the end like ..../downloads/ and no '~'): {ANSI_RESET} ")  
 
     # Open each KMF file
     for i in range(numLogs):


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
Now instead of going into the code to change the path you will input it to the memorator upload script:

![image](https://github.com/user-attachments/assets/4412fd99-052b-4758-920b-c3dcb5bbec61)
The runtime counter is in a weird spot and multiple combinations of newlines added to the input string I print doesnt move it out the way. This is the only way that looks most sane. A problem for when we arnt using command line...



## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [x] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [x] Other
- [ ] N/A

<!-- Describe your testing steps here -->
I copied my full path with the '/' at the end and then inputted that and it worked and i see the data on influxdb.

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
