### PR TITLE
Fix: Fixed timestamp issue of 10 seconds on and off of data

### DIFF
--- a/tools/MemoratorUploader.py
+++ b/tools/MemoratorUploader.py
@@ -31,9 +31,13 @@ SEND_TO_PARSER_DELAY    = 0.006
 
 def upload(log_file: kvmlib.LogFile, parserCallFunc: callable, live_filters: list,  log_filters: list, display_filters: list, args: list, endpoint: str):
     start_time = None
+    got_start_time = False
+
     for event in log_file:
         str_event = str(event)
-        if PATTERN_DATETIME.search(str_event):
+        if not got_start_time and PATTERN_DATETIME.search(str_event):
+            got_start_time = True
+            
             match = PATTERN_DATETIME.search(str_event)
             date_time_str = match.group(2)
             date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d %H:%M:%S') 


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
STG and I noticed that the data on InfluxDB has a weird 10 seconds on and off issue:
![image](https://github.com/user-attachments/assets/231ff3cf-f18c-4e72-a9ea-f4272d41d554)

This was due to noticing that the KMF files inject a new start time every 10 seconds into their log files. Thus, a bug appeared in the memorator uploader script where the start time was by 10 seconds but the difference in time the KMF gave us was **still relative to the very first start time they gave us**.  Fixed now with simple logic to take the first start time and ignore every instance of a start time after that.

## Monday Link
<!-- Copy related Monday issue here -->
https://ubcsolar26.monday.com/boards/7524367653/pulses/7576633454/posts/3513794330

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [x] Influx
- [ ] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [ ] Other
- [ ] N/A

Tested by uploading memorator data locally and viewing no 10 seconds off and off issue.

<!-- Describe your testing steps here -->

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
