### PR TITLE
Refactor: DBC Removed msgs with no signals

### DIFF
--- a/dbc/brightside.dbc
+++ b/dbc/brightside.dbc
@@ -311,24 +311,6 @@ BO_ 2566869221 OBCStatus: 8 OBC
  SG_ S2SwitchControlStatus : 55|1@1+ (1,0) [0|0] "" Vector__XXX
  SG_ Temperaturre : 56|8@1+ (1,-40) [0|0] "C" Vector__XXX
 
-BO_ 1284 PhaseCurrentMeasurement: 8 MDI
-
-BO_ 1285 MotorVoltageVectorMeasurment: 8 MDI
-
-BO_ 1286 MotorCurrentVectorMeasurment: 8 MDI
-
-BO_ 1287 MotorBackEMFMeasurement: 8 MDI
-
-BO_ 1288 VoltageRailMeasurement_FifteenV: 8 MDI
-
-BO_ 1289 VoltageRailMeasurement_TwoFiveV: 8 MDI
-
-BO_ 1290 FanSpeedMeasurement: 8 MDI
-
-BO_ 1292 AirInCPUTemperatureMeasurement: 8 MDI
-
-BO_ 1294 OdometerBusAmpHoursMeasurement: 8 MDI
-
 BO_ 2297992512 MitsubaDataRequest: 1 MC
  SG_ RequestForFrames : 0|1@1+ (2,0) [0|0] "" Vector__XXX
 


### PR DESCRIPTION
## Sunlink Pull Request Description
<!-- Describe your PR here -->
Problem is that you would get annoying failed to parse messages in the terminal when you run sunlink in randomizer because some messages did not have signals associated with them. The fix is to just delete them; we do not use them.

## Monday Link
<!-- Copy related Monday issue here -->

## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [ ] Grafana
- [x] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [ ] Other
- [ ] N/A

<!-- Describe your testing steps here -->
Ran randomizer again and everything worked perfectly.

## Sanity check
<!-- Check box if all steps complete (check even if not applicable) -->
- CAN ID table / DBC updated
- gitignore updated and commited
- [ ] Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
