### PR TITLE
Grafana Dashboard Refresh+Window Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ telemetry.toml
 logfiles/*
 dbgfiles/*
 failfiles/*
-logs/*.DS_Store
+**.DS_Store

--- a/dashboards/LOG/LOG_Pit_Crew_Brightside.json
+++ b/dashboards/LOG/LOG_Pit_Crew_Brightside.json
@@ -4894,7 +4894,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -4902,7 +4902,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1m",
     "to": "now"
   },
   "timepicker": {

--- a/dashboards/PROD/PROD_DRD_Brightside.json
+++ b/dashboards/PROD/PROD_DRD_Brightside.json
@@ -810,7 +810,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1m",
     "to": "now"
   },
   "timepicker": {

--- a/dashboards/PROD/PROD_MDI_Brightside.json
+++ b/dashboards/PROD/PROD_MDI_Brightside.json
@@ -186,7 +186,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "",
+  "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],

--- a/dashboards/PROD/PROD_Pit_Crew_Brightside.json
+++ b/dashboards/PROD/PROD_Pit_Crew_Brightside.json
@@ -4894,7 +4894,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -4902,7 +4902,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1m",
     "to": "now"
   },
   "timepicker": {

--- a/dashboards/PROD/PROD_STR_Brightside.json
+++ b/dashboards/PROD/PROD_STR_Brightside.json
@@ -377,7 +377,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "",
+  "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],

--- a/dashboards/TEST/TEST_Pit_Crew_Brightside.json
+++ b/dashboards/TEST/TEST_Pit_Crew_Brightside.json
@@ -4894,7 +4894,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "1s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -4902,7 +4902,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1m",
     "to": "now"
   },
   "timepicker": {


### PR DESCRIPTION
## Sunlink Pull Request Description
I changed all dashboard settings to automatically load refresh and window settings as '1s' and 'now-1m'.

## Monday Link


## Effected Components
<!-- Check which components are affected -->
- [ ] Link Telemetry
- [ ] Parser
- [ ] Influx
- [√] Grafana
- [ ] DBC
- [ ] Sunlink environment
- [ ] Tools
- [ ] Tests
- [ ] Docs


## Testing
<!-- Check which testing was done -->
- [ ] Vehicle testing
- [ ] Randomizer testing
- [√] Loaded 'localhost:3000' on uncached browser and had window+refresh settings preloaded.


## Sanity check
√ CAN ID table / DBC updated
√ gitignore updated and commited
√ Steps confirmed

## Sources
<!-- Added any links to articles or videos used -->
